### PR TITLE
Remove Optima branding from data model

### DIFF
--- a/app/models/external_sync_log.rb
+++ b/app/models/external_sync_log.rb
@@ -1,6 +1,6 @@
-class OptimaSyncLog < ApplicationRecord
+class ExternalSyncLog < ApplicationRecord
   enum :sync_type, { pull: 0, push: 1, full: 2 }
-  enum :sync_direction, { from_optima: 0, to_optima: 1 }
+  enum :sync_direction, { inbound: 0, outbound: 1 }
   enum :status, { started: 0, completed: 1, failed: 2 }
 
   belongs_to :volunteer, optional: true

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -13,7 +13,7 @@ class Volunteer < ApplicationRecord
   has_many :status_changes, dependent: :destroy
   has_many :scheduled_reminders, dependent: :destroy
   has_many :inquiry_form_submissions, dependent: :nullify
-  has_many :optima_sync_logs, dependent: :nullify
+  has_many :external_sync_logs, dependent: :nullify
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/db/migrate/20260131000004_create_volunteers.rb
+++ b/db/migrate/20260131000004_create_volunteers.rb
@@ -2,8 +2,8 @@ class CreateVolunteers < ActiveRecord::Migration[8.1]
   def change
     create_table :volunteers do |t|
       # Core identification
-      t.string :optima_id
-      t.datetime :optima_synced_at
+      t.string :external_id
+      t.datetime :external_synced_at
 
       # Personal info
       t.string :first_name, null: false
@@ -38,7 +38,7 @@ class CreateVolunteers < ActiveRecord::Migration[8.1]
     end
 
     add_index :volunteers, :email, unique: true
-    add_index :volunteers, :optima_id
+    add_index :volunteers, :external_id
     add_index :volunteers, :current_funnel_stage
     add_index :volunteers, :inquiry_date
     add_index :volunteers, :became_inactive_at

--- a/db/migrate/20260131000012_create_external_sync_logs.rb
+++ b/db/migrate/20260131000012_create_external_sync_logs.rb
@@ -1,6 +1,6 @@
-class CreateOptimaSyncLogs < ActiveRecord::Migration[8.1]
+class CreateExternalSyncLogs < ActiveRecord::Migration[8.1]
   def change
-    create_table :optima_sync_logs do |t|
+    create_table :external_sync_logs do |t|
       t.references :volunteer, foreign_key: true
       t.integer :sync_type, default: 0, null: false
       t.integer :sync_direction, default: 0, null: false
@@ -14,7 +14,7 @@ class CreateOptimaSyncLogs < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :optima_sync_logs, :status
-    add_index :optima_sync_logs, :started_at
+    add_index :external_sync_logs, :status
+    add_index :external_sync_logs, :started_at
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,6 +48,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_31_000013) do
     t.index ["volunteer_id"], name: "index_communications_on_volunteer_id"
   end
 
+  create_table "external_sync_logs", force: :cascade do |t|
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.text "error_message"
+    t.jsonb "payload_snapshot"
+    t.integer "records_processed"
+    t.datetime "started_at"
+    t.integer "status", default: 0, null: false
+    t.integer "sync_direction", default: 0, null: false
+    t.integer "sync_type", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "volunteer_id"
+    t.index ["started_at"], name: "index_external_sync_logs_on_started_at"
+    t.index ["status"], name: "index_external_sync_logs_on_status"
+    t.index ["volunteer_id"], name: "index_external_sync_logs_on_volunteer_id"
+  end
+
   create_table "information_sessions", force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.integer "capacity"
@@ -84,23 +101,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_31_000013) do
     t.bigint "volunteer_id", null: false
     t.index ["user_id"], name: "index_notes_on_user_id"
     t.index ["volunteer_id"], name: "index_notes_on_volunteer_id"
-  end
-
-  create_table "optima_sync_logs", force: :cascade do |t|
-    t.datetime "completed_at"
-    t.datetime "created_at", null: false
-    t.text "error_message"
-    t.jsonb "payload_snapshot"
-    t.integer "records_processed"
-    t.datetime "started_at"
-    t.integer "status", default: 0, null: false
-    t.integer "sync_direction", default: 0, null: false
-    t.integer "sync_type", default: 0, null: false
-    t.datetime "updated_at", null: false
-    t.bigint "volunteer_id"
-    t.index ["started_at"], name: "index_optima_sync_logs_on_started_at"
-    t.index ["status"], name: "index_optima_sync_logs_on_status"
-    t.index ["volunteer_id"], name: "index_optima_sync_logs_on_volunteer_id"
   end
 
   create_table "referral_sources", force: :cascade do |t|
@@ -185,13 +185,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_31_000013) do
     t.datetime "created_at", null: false
     t.integer "current_funnel_stage", default: 0, null: false
     t.string "email", null: false
+    t.string "external_id"
+    t.datetime "external_synced_at"
     t.string "first_name", null: false
     t.datetime "first_session_attended_at"
     t.integer "inactive_reason"
     t.datetime "inquiry_date"
     t.string "last_name", null: false
-    t.string "optima_id"
-    t.datetime "optima_synced_at"
     t.string "phone"
     t.integer "preferred_contact_method", default: 0, null: false
     t.datetime "reactivated_at"
@@ -203,8 +203,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_31_000013) do
     t.index ["became_inactive_at"], name: "index_volunteers_on_became_inactive_at"
     t.index ["current_funnel_stage"], name: "index_volunteers_on_current_funnel_stage"
     t.index ["email"], name: "index_volunteers_on_email", unique: true
+    t.index ["external_id"], name: "index_volunteers_on_external_id"
     t.index ["inquiry_date"], name: "index_volunteers_on_inquiry_date"
-    t.index ["optima_id"], name: "index_volunteers_on_optima_id"
     t.index ["referral_source_id"], name: "index_volunteers_on_referral_source_id"
     t.index ["referred_by_volunteer_id"], name: "index_volunteers_on_referred_by_volunteer_id"
   end
@@ -212,10 +212,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_31_000013) do
   add_foreign_key "communications", "communication_templates"
   add_foreign_key "communications", "users", column: "sent_by_user_id"
   add_foreign_key "communications", "volunteers"
+  add_foreign_key "external_sync_logs", "volunteers"
   add_foreign_key "inquiry_form_submissions", "volunteers"
   add_foreign_key "notes", "users"
   add_foreign_key "notes", "volunteers"
-  add_foreign_key "optima_sync_logs", "volunteers"
   add_foreign_key "scheduled_reminders", "communication_templates"
   add_foreign_key "scheduled_reminders", "volunteers"
   add_foreign_key "session_registrations", "information_sessions"

--- a/docs/user-stories/11-integration-admin.md
+++ b/docs/user-stories/11-integration-admin.md
@@ -5,9 +5,9 @@
 **So that** data stays synchronized and the system is configurable
 
 **Acceptance Criteria:**
-- System notifies when volunteer data is transferred to Optima
+- System notifies when volunteer data is transferred to the external system
 - Transfer status visible in volunteer profile with date/time
-- When application is submitted, data is sent through a custom API to Optima
+- When application is submitted, data is sent through a custom API to the external system
 - Volunteers remain in the system for future email communications
 - Role-based access control for administrators
 - Administrators can change reminder frequencies and manage email templates


### PR DESCRIPTION
Rename OptimaSyncLog to ExternalSyncLog and replace all Optima-specific terminology with generic external system naming. Updates field names from optima_id/optima_synced_at to external_id/external_synced_at, and sync_direction enum values from from_optima/to_optima to inbound/outbound.