### PR TITLE
Add User Story 12: User Login

### DIFF
--- a/docs/user-stories/12-user-login.md
+++ b/docs/user-stories/12-user-login.md
@@ -1,0 +1,9 @@
+# User Login
+
+**As a** volunteer or administrator  
+**I want to** sign in using my Gmail account  
+**So that** I can access the system without managing a separate password
+
+**Acceptance Criteria:**
+- Users sign in via OAuth using their Gmail account
+- Only Gmail accounts affiliated with the CASA email domain are accepted


### PR DESCRIPTION
Adds the user login user story describing OAuth-based sign-in with Gmail accounts on the CASA domain.

@wessimpson @izzyyadams @ivlarson20, please review. We will need to add this to the cheat sheet we're providing for Friday's presentation. It's already covered in the LoFi Diagrams.