### PR TITLE
Add VMS Lambda transformers with RSpec test setup

### DIFF
--- a/lambdas/vms/.rspec
+++ b/lambdas/vms/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format documentation
+--color

--- a/lambdas/vms/Gemfile
+++ b/lambdas/vms/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "aws-sdk-secretsmanager"
+gem "aws-sdk-lambda"
+
+group :test do
+  gem "rspec", "~> 3.13"
+  gem "webmock", "~> 3.23"
+end

--- a/lambdas/vms/Gemfile.lock
+++ b/lambdas/vms/Gemfile.lock
@@ -1,0 +1,88 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.9)
+      public_suffix (>= 2.0.2, < 8.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1232.0)
+    aws-sdk-core (3.244.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-lambda (1.176.0)
+      aws-sdk-core (~> 3, >= 3.244.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-secretsmanager (1.129.0)
+      aws-sdk-core (~> 3, >= 3.244.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    bigdecimal (4.1.0)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    diff-lcs (1.6.2)
+    hashdiff (1.2.1)
+    jmespath (1.6.2)
+    logger (1.7.0)
+    public_suffix (7.0.5)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  aws-sdk-lambda
+  aws-sdk-secretsmanager
+  rspec (~> 3.13)
+  webmock (~> 3.23)
+
+CHECKSUMS
+  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
+  aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
+  aws-partitions (1.1232.0) sha256=5d7d8cda52e2ed3d1fdfff185efb2f4e6ded944efc8ae7ece0d2438393f9feb6
+  aws-sdk-core (3.244.0) sha256=3e458c078b0c5bdee95bc370c3a483374b3224cf730c1f9f0faf849a5d9a18ea
+  aws-sdk-lambda (1.176.0) sha256=0562c2816dcb6dbca3c0d416b180ea71f296eb8034acd87a95d2ab9e1d00e545
+  aws-sdk-secretsmanager (1.129.0) sha256=00445c87a8096da92c9d21ea52bb3d9e3634ae6e62f1b248eb9176f86470c954
+  aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.1.0) sha256=6dc07767aa3dc456ccd48e7ae70a07b474e9afd7c5bc576f80bd6da5c8dd6cae
+  crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
+
+BUNDLED WITH
+  4.0.4

--- a/lambdas/vms/spec/spec_helper.rb
+++ b/lambdas/vms/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "webmock/rspec"
 require "json"
 require "net/http"
 
@@ -16,18 +15,8 @@ module Shared
   end
 end
 
-require "session_manager"
-require "http_client"
-require "resources/inquiry"
-require "resources/volunteer"
-require "resources/lookup"
 require "transformers/field_normalizer"
 require "transformers/kendo_response"
-
-# Load handler (defines top-level methods)
-require "handler"
-
-require_relative "support/fake_http_client"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -40,7 +29,4 @@ RSpec.configure do |config|
 
   config.order = :random
   config.shared_context_metadata_behavior = :apply_to_host_groups
-
-  # Disable all external HTTP by default
-  WebMock.disable_net_connect!
 end

--- a/lambdas/vms/spec/spec_helper.rb
+++ b/lambdas/vms/spec/spec_helper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "webmock/rspec"
+require "json"
+require "net/http"
+
+# Add lambda source to load path
+$LOAD_PATH.unshift(File.join(__dir__, ".."))
+
+# Stub the shared logger before any source requires it
+module Shared
+  module Log
+    def self.logger
+      @logger ||= Logger.new(File::NULL)
+    end
+  end
+end
+
+require "session_manager"
+require "http_client"
+require "resources/inquiry"
+require "resources/volunteer"
+require "resources/lookup"
+require "transformers/field_normalizer"
+require "transformers/kendo_response"
+
+# Load handler (defines top-level methods)
+require "handler"
+
+require_relative "support/fake_http_client"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.order = :random
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # Disable all external HTTP by default
+  WebMock.disable_net_connect!
+end

--- a/lambdas/vms/spec/transformers/field_normalizer_spec.rb
+++ b/lambdas/vms/spec/transformers/field_normalizer_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe Vms::Transformers::FieldNormalizer do
+  describe ".pascal_to_snake" do
+    it "converts simple PascalCase" do
+      expect(described_class.pascal_to_snake("FirstName")).to eq("first_name")
+    end
+
+    it "converts consecutive capitals" do
+      expect(described_class.pascal_to_snake("PartyID")).to eq("party_id")
+    end
+
+    it "converts camelCase" do
+      expect(described_class.pascal_to_snake("firstName")).to eq("first_name")
+    end
+
+    it "handles single word" do
+      expect(described_class.pascal_to_snake("Active")).to eq("active")
+    end
+  end
+
+  describe ".snake_to_pascal" do
+    it "converts snake_case to PascalCase" do
+      expect(described_class.snake_to_pascal("first_name")).to eq("FirstName")
+    end
+  end
+
+  describe ".normalize_value" do
+    it "parses ASP.NET date format to ISO 8601" do
+      expect(described_class.normalize_value("/Date(1710460800000)/")).to eq("2024-03-15")
+    end
+
+    it "passes through non-date strings" do
+      expect(described_class.normalize_value("Jane")).to eq("Jane")
+    end
+
+    it "passes through non-string values" do
+      expect(described_class.normalize_value(42)).to eq(42)
+      expect(described_class.normalize_value(true)).to eq(true)
+      expect(described_class.normalize_value(nil)).to be_nil
+    end
+  end
+
+  describe ".normalize_record" do
+    it "converts PascalCase keys to snake_case" do
+      record = { "FirstName" => "Jane", "LastName" => "Smith" }
+      result = described_class.normalize_record(record)
+      expect(result).to eq("first_name" => "Jane", "last_name" => "Smith")
+    end
+
+    it "applies FIELD_ALIASES for known special fields" do
+      record = { "EncyptedPartyID" => "abc==" }
+      result = described_class.normalize_record(record)
+      expect(result).to eq("encrypted_party_id" => "abc==")
+    end
+
+    it "parses ASP.NET dates in values" do
+      record = { "Inquired" => "/Date(1710460800000)/" }
+      result = described_class.normalize_record(record)
+      expect(result["inquired"]).to eq("2024-03-15")
+    end
+
+    it "handles all FIELD_ALIASES" do
+      %w[EncryptedID InquiryID PartyID ProgramID CountyID].each do |key|
+        record = { key => "val" }
+        result = described_class.normalize_record(record)
+        expect(result.keys.first).to match(/\A[a-z_]+\z/)
+      end
+    end
+  end
+
+  describe ".normalize_records" do
+    it "normalizes a batch of records" do
+      records = [
+        { "FirstName" => "A" },
+        { "FirstName" => "B" }
+      ]
+      result = described_class.normalize_records(records)
+      expect(result.map { |r| r["first_name"] }).to eq(%w[A B])
+    end
+  end
+end

--- a/lambdas/vms/spec/transformers/kendo_response_spec.rb
+++ b/lambdas/vms/spec/transformers/kendo_response_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Vms::Transformers::KendoResponse do
+  describe ".parse" do
+    it "parses PascalCase keys (Data/Total)" do
+      json = '{"Data": [{"Name": "A"}], "Total": 1}'
+      result = described_class.parse(json)
+      expect(result["data"]).to eq([{ "Name" => "A" }])
+      expect(result["total"]).to eq(1)
+    end
+
+    it "parses lowercase keys (data/total)" do
+      json = '{"data": [{"Name": "B"}], "total": 2}'
+      result = described_class.parse(json)
+      expect(result["data"]).to eq([{ "Name" => "B" }])
+      expect(result["total"]).to eq(2)
+    end
+
+    it "returns empty array when no data key" do
+      json = '{"Total": 0}'
+      result = described_class.parse(json)
+      expect(result["data"]).to eq([])
+      expect(result["total"]).to eq(0)
+    end
+
+    it "defaults total to data length when missing" do
+      json = '{"data": [{"a": 1}, {"a": 2}]}'
+      result = described_class.parse(json)
+      expect(result["total"]).to eq(2)
+    end
+
+    it "raises on invalid JSON" do
+      expect { described_class.parse("not json") }.to raise_error(JSON::ParserError)
+    end
+  end
+end

--- a/lambdas/vms/spec/transformers/kendo_response_spec.rb
+++ b/lambdas/vms/spec/transformers/kendo_response_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Vms::Transformers::KendoResponse do
     it "parses PascalCase keys (Data/Total)" do
       json = '{"Data": [{"Name": "A"}], "Total": 1}'
       result = described_class.parse(json)
-      expect(result["data"]).to eq([{ "Name" => "A" }])
+      expect(result["data"]).to eq([ { "Name" => "A" } ])
       expect(result["total"]).to eq(1)
     end
 
     it "parses lowercase keys (data/total)" do
       json = '{"data": [{"Name": "B"}], "total": 2}'
       result = described_class.parse(json)
-      expect(result["data"]).to eq([{ "Name" => "B" }])
+      expect(result["data"]).to eq([ { "Name" => "B" } ])
       expect(result["total"]).to eq(2)
     end
 

--- a/lambdas/vms/transformers/field_normalizer.rb
+++ b/lambdas/vms/transformers/field_normalizer.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Vms
+  module Transformers
+    # Converts between Sprout's snake_case and VMS's PascalCase.
+    # Parses ASP.NET date format (/Date(ms)/) into ISO 8601.
+    # Handles known VMS quirks (e.g., EncyptedPartyID typo).
+    module FieldNormalizer
+      # ASP.NET JSON date pattern: /Date(1771495200000)/
+      DATE_PATTERN = %r{/Date\((\d+)\)/}
+
+      # Map of VMS PascalCase field names to Sprout snake_case.
+      # Only includes fields that need special handling beyond simple conversion.
+      FIELD_ALIASES = {
+        "EncyptedPartyID" => "encrypted_party_id",  # VMS typo — missing 'r'
+        "EncryptedID" => "encrypted_id",
+        "InquiryID" => "inquiry_id",
+        "PartyID" => "party_id",
+        "ProgramID" => "program_id",
+        "CountyID" => "county_id"
+      }.freeze
+
+      module_function
+
+      # Convert a VMS record hash from PascalCase to snake_case.
+      # Also parses ASP.NET date values.
+      def normalize_record(record)
+        result = {}
+        record.each do |key, value|
+          snake_key = FIELD_ALIASES[key] || pascal_to_snake(key)
+          result[snake_key] = normalize_value(value)
+        end
+        result
+      end
+
+      # Convert a batch of records.
+      def normalize_records(records)
+        records.map { |r| normalize_record(r) }
+      end
+
+      # Convert PascalCase or camelCase to snake_case.
+      def pascal_to_snake(str)
+        str.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+           .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+           .downcase
+      end
+
+      # Convert snake_case to PascalCase (for sending data to VMS).
+      def snake_to_pascal(str)
+        str.split("_").map(&:capitalize).join
+      end
+
+      # Normalize a single value — parse ASP.NET dates, pass through everything else.
+      def normalize_value(value)
+        return value unless value.is_a?(String)
+
+        match = value.match(DATE_PATTERN)
+        return value unless match
+
+        # Convert milliseconds since epoch to ISO 8601 date
+        timestamp_ms = match[1].to_i
+        Time.at(timestamp_ms / 1000).utc.strftime("%Y-%m-%d")
+      end
+
+    end
+  end
+end

--- a/lambdas/vms/transformers/field_normalizer.rb
+++ b/lambdas/vms/transformers/field_normalizer.rb
@@ -61,7 +61,6 @@ module Vms
         timestamp_ms = match[1].to_i
         Time.at(timestamp_ms / 1000).utc.strftime("%Y-%m-%d")
       end
-
     end
   end
 end

--- a/lambdas/vms/transformers/kendo_response.rb
+++ b/lambdas/vms/transformers/kendo_response.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Vms
+  module Transformers
+    # Parses Kendo UI grid JSON responses from VMS AJAX endpoints.
+    #
+    # VMS Kendo grids lazy-load data via AJAX POST to /{Controller}/_Index.
+    # Response format: {"data": [...records...], "total": N}
+    module KendoResponse
+      module_function
+
+      # Parse a Kendo grid AJAX response.
+      # Returns { data: [...], total: N }
+      def parse(response_body)
+        parsed = JSON.parse(response_body)
+
+        # Kendo responses have "Data" (PascalCase) and "Total"
+        data = parsed["Data"] || parsed["data"] || []
+        total = parsed["Total"] || parsed["total"] || data.length
+
+        { "data" => data, "total" => total }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `FieldNormalizer` transformer for VMS field name/value mapping
- Adds `KendoResponse` transformer for parsing Kendo UI JSON format
- Sets up RSpec test harness for VMS Lambda (Gemfile, spec_helper, .rspec)
- Includes passing specs for both transformers

## Context
This is **PR 2 of 5** in the VMS scraper API implementation. These transformers are the foundation layer with zero VMS dependencies — they handle data format conversion that all resources build on.

**PR chain:** PR 1 (design doc) → **PR 2 (this)** → PR 3 (session/HTTP/resources) → PR 4 (handlers) → PR 5 (Rails + infra)

## Test plan
- [ ] `cd lambdas/vms && bundle install && bundle exec rspec spec/transformers/` — all specs pass
- [ ] Review FieldNormalizer mappings match VMS field names from design doc
- [ ] Review KendoResponse parsing handles edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #116