### PR TITLE
[User Story 8 Refactor] Notes Tracking

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -18,6 +18,10 @@
   input[type="text"],
   input[type="email"],
   input[type="tel"],
+  input[type="date"],
+  input[type="datetime-local"],
+  input[type="number"],
+  select,
   textarea {
     @apply border border-gray-400 rounded-md bg-white;
   }
@@ -51,6 +55,10 @@
     @apply w-full max-w-full min-h-[5.5rem] border border-gray-400 rounded-md p-2 text-base;
   }
 
+  .note-form .button-primary {
+    @apply mt-3;
+  }
+
   /* SMS compose: visible field, bounded height (no endless vertical resize). */
   .sms-compose-form {
     @apply grid gap-3;
@@ -72,21 +80,40 @@
     @apply flex gap-2 items-center;
   }
 
+  /* Primary destination link: lighter than a faux button; chevron reads as “up” navigation. */
+  .page-nav--back {
+    @apply mb-3;
+  }
+
+  .nav-back {
+    @apply group inline-flex max-w-full items-center gap-2.5 rounded-lg py-1 pr-2 text-left text-sm font-medium text-slate-700 no-underline transition-colors hover:bg-slate-100 hover:text-slate-950;
+  }
+
+  .nav-back:focus-visible {
+    @apply rounded-lg outline outline-2 outline-offset-2 outline-indigo-500;
+  }
+
+  .nav-back__chevron {
+    @apply flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-base leading-none text-slate-500 shadow-sm transition group-hover:border-slate-300 group-hover:text-slate-800;
+  }
+
   #actions {
     @apply grid gap-3.5;
   }
 
+  /* One sizing contract for default actions (see .button-primary for primary). */
   button,
   .button-link {
-    @apply inline-block box-border min-h-[38px] border border-gray-400 rounded-md px-2.5 py-1.5 bg-gray-50 text-gray-900 no-underline cursor-pointer text-base leading-tight font-[inherit];
+    @apply m-0 inline-flex h-11 shrink-0 items-center justify-center box-border border border-gray-400 rounded-md bg-gray-50 px-4 text-center text-sm font-semibold text-gray-900 no-underline cursor-pointer;
   }
 
+  /* Full contract: used on <button> and on button_to <input type="submit"> (not covered by `button`). */
   .btn-note {
-    @apply bg-sky-100 border-sky-300;
+    @apply m-0 inline-flex h-11 shrink-0 items-center justify-center box-border rounded-md border border-sky-300 bg-sky-100 px-4 text-center text-sm font-semibold text-gray-900 cursor-pointer;
   }
 
   .btn-delete {
-    @apply bg-red-100 border-red-300;
+    @apply m-0 inline-flex h-11 shrink-0 items-center justify-center box-border rounded-md border border-red-300 bg-red-100 px-4 text-center text-sm font-semibold text-red-900 cursor-pointer appearance-none;
   }
 
   .communication-entry,
@@ -182,6 +209,20 @@
     @apply flex flex-col items-start gap-3;
   }
 
+  /* New / edit information session: use full card width for fields (see .input-large max-w-md). */
+  .volunteer-page .information-session-form {
+    @apply w-full max-w-none items-stretch;
+  }
+
+  .volunteer-page .information-session-form .form-row {
+    @apply w-full min-w-0;
+  }
+
+  .volunteer-page .information-session-form .input-large,
+  .volunteer-page .information-session-form select {
+    @apply w-full max-w-none;
+  }
+
   .form-row,
   .status-update-form .form-row {
     @apply flex flex-col gap-1.5;
@@ -198,7 +239,7 @@
   }
 
   .button-primary {
-    @apply min-h-11 px-4 py-2 font-semibold border border-blue-600 rounded-md bg-blue-50 text-blue-900 cursor-pointer text-base;
+    @apply m-0 inline-flex h-11 shrink-0 items-center justify-center box-border border border-indigo-600 rounded-md bg-indigo-600 px-4 text-center text-sm font-semibold text-white no-underline cursor-pointer appearance-none;
   }
 
   .timeline-filter-form {
@@ -258,6 +299,199 @@
     @apply mt-4;
   }
 
+  /* Information sessions index */
+  .sessions-page {
+    @apply max-w-6xl mx-auto p-4 pb-10 text-base text-gray-900;
+  }
+
+  .sessions-index .card {
+    @apply mb-0;
+  }
+
+  .sessions-index__title,
+  .sessions-page-header {
+    @apply mb-0;
+  }
+
+  .sessions-filter-card {
+    @apply p-4;
+  }
+
+  .sessions-filter-card .sessions-filter-grid {
+    @apply grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4;
+  }
+
+  .sessions-filter-card .form-row {
+    @apply min-w-0 flex flex-col gap-2;
+  }
+
+  .sessions-filter-card .input-large {
+    @apply w-full max-w-none;
+  }
+
+  .sessions-filter-card .form-row label {
+    @apply mb-0 block text-sm font-semibold text-gray-800;
+  }
+
+  .sessions-filter-card input[type="date"],
+  .sessions-filter-card select {
+    @apply w-full min-h-[42px] text-base px-2.5 py-1.5 box-border;
+  }
+
+  .sessions-filter-card .sessions-filter-actions {
+    @apply col-span-full flex flex-col gap-3 border-t border-gray-200 pt-4;
+  }
+
+  @media (width >= 40rem) {
+    .sessions-filter-card .sessions-filter-actions {
+      @apply flex-row;
+    }
+  }
+
+  .sessions-filter-card .sessions-filter-actions .button-primary,
+  .sessions-filter-card .sessions-filter-actions button[type="submit"],
+  .sessions-filter-card .sessions-filter-actions .button-link {
+    @apply min-w-0 max-w-none h-11 w-full;
+  }
+
+  @media (width >= 40rem) {
+    .sessions-filter-card .sessions-filter-actions .button-primary,
+    .sessions-filter-card .sessions-filter-actions button[type="submit"],
+    .sessions-filter-card .sessions-filter-actions .button-link {
+      @apply flex-1 basis-0;
+    }
+  }
+
+  .sessions-toolbar-btn {
+    @apply max-w-full whitespace-normal text-center [overflow-wrap:anywhere];
+  }
+
+  .sessions-page-create {
+    @apply mb-0;
+  }
+
+  .sessions-page-create__btn {
+    @apply w-full sm:w-auto;
+  }
+
+  .sessions-session-actions {
+    @apply flex max-w-full flex-wrap justify-end gap-2;
+  }
+
+  .sessions-history-heading {
+    @apply mb-2 mt-0;
+  }
+
+  .sessions-history-help {
+    @apply mb-4 mt-0;
+  }
+
+  .sessions-history-list {
+    @apply gap-0 px-4 py-2;
+  }
+
+  /* FIX 2: Allow actions to wrap below content on narrow screens so the card
+     never clips. Items stay top-aligned so long names don't misalign buttons. */
+  .session-history-card.volunteer-row {
+    @apply py-4 flex-wrap items-start;
+  }
+
+  .session-history-card .volunteer-meta {
+    @apply gap-2 pr-2 min-w-0 flex-1;
+  }
+
+  .session-history-meta {
+    @apply mt-2 flex-wrap gap-x-3 gap-y-1;
+  }
+
+  .session-history-created-by {
+    @apply m-0 mt-2 text-sm leading-snug text-gray-600;
+  }
+
+  /* FIX 3: Participants table — column separators stop name/email from smushing. */
+  .sessions-participants-wrap {
+    @apply mt-2;
+  }
+
+  .sessions-participants-table {
+    @apply w-full table-fixed border-collapse text-left text-base;
+  }
+
+  .sessions-participants-table th,
+  .sessions-participants-table td {
+    @apply border-b border-gray-200 px-4 py-3 align-middle;
+  }
+
+  /* Vertical divider between columns */
+  .sessions-participants-table th:not(:last-child),
+  .sessions-participants-table td:not(:last-child) {
+    @apply border-r border-gray-100;
+  }
+
+  .sessions-participants-table thead th {
+    @apply bg-gray-50 text-sm font-semibold text-gray-800;
+  }
+
+  .sessions-participants-col-name {
+    @apply w-[28%];
+  }
+
+  .sessions-participants-col-email {
+    @apply w-[52%];
+  }
+
+  .sessions-participants-col-actions {
+    @apply w-[20%];
+  }
+
+  .sessions-participants-name {
+    @apply whitespace-normal break-words pr-2 font-medium text-gray-900;
+  }
+
+  .sessions-participants-email {
+    @apply min-w-0 whitespace-normal break-all text-gray-800;
+  }
+
+  .sessions-participants-actions {
+    @apply text-right align-middle;
+  }
+
+  .sessions-table-wrap {
+    @apply overflow-x-auto rounded-lg border border-gray-300 bg-white shadow-sm;
+  }
+
+  .sessions-table {
+    @apply w-full min-w-[36rem] border-collapse text-left text-sm;
+  }
+
+  .sessions-table thead th {
+    @apply border-b border-gray-300 bg-gray-50 px-3 py-2.5 font-semibold text-gray-800 whitespace-nowrap;
+  }
+
+  .sessions-table tbody td {
+    @apply border-b border-gray-200 px-3 py-2.5 align-middle text-gray-900;
+  }
+
+  .sessions-table tbody tr:last-child td {
+    @apply border-b-0;
+  }
+
+  .sessions-table .sessions-actions {
+    @apply flex flex-wrap items-center justify-end gap-2 whitespace-nowrap;
+  }
+
+  .sessions-empty {
+    @apply text-gray-600 py-6 px-3 text-center text-base border border-dashed border-gray-300 rounded-lg bg-gray-50/80;
+  }
+
+  .sessions-page-header {
+    @apply mb-0 flex flex-row flex-wrap items-center justify-between gap-3;
+  }
+
+  .sessions-page-header .page-title {
+    @apply mb-0;
+  }
+
   .errors {
     @apply text-red-700 text-sm mt-2;
   }
@@ -276,6 +510,10 @@
 
   .inquiry-form .input-large {
     @apply max-w-xl border-gray-400 bg-white;
+  }
+
+  .inquiry-form .button-primary {
+    @apply mt-1;
   }
 
   .inquiry-form__inline {
@@ -362,5 +600,29 @@
 
   .flash-banner--alert {
     @apply bg-amber-50/90 text-amber-950 border-amber-200;
+  }
+
+  .sessions-pagination {
+    @apply mt-6 flex flex-wrap items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm;
+  }
+
+  .sessions-pagination__pages {
+    @apply m-0 flex list-none flex-wrap items-center gap-1 p-0;
+  }
+
+  .sessions-pagination__pages li {
+    @apply m-0 p-0;
+  }
+
+  .sessions-pagination__current {
+    @apply inline-flex h-9 min-w-[2.25rem] items-center justify-center rounded-md border border-sky-300 bg-sky-50 px-2.5 text-sm font-semibold text-sky-900;
+  }
+
+  .sessions-pagination__link.button-link {
+    @apply h-9 min-w-[2.25rem] border-gray-200 bg-transparent px-2.5 text-sm text-gray-700 hover:bg-gray-50;
+  }
+
+  .sessions-pagination__control {
+    @apply h-9 shrink-0 gap-1.5 border-gray-200 bg-transparent px-3 text-sm text-gray-700 hover:bg-gray-50;
   }
 }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -86,7 +86,7 @@
   }
 
   .nav-back {
-    @apply group inline-flex max-w-full items-center gap-2.5 rounded-lg py-1 pr-2 text-left text-sm font-medium text-slate-700 no-underline transition-colors hover:bg-slate-100 hover:text-slate-950;
+    @apply inline-flex max-w-full items-center gap-2.5 rounded-lg py-1 pr-2 text-left text-sm font-medium text-slate-700 no-underline transition-colors hover:bg-slate-100 hover:text-slate-950;
   }
 
   .nav-back:focus-visible {
@@ -94,7 +94,11 @@
   }
 
   .nav-back__chevron {
-    @apply flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-base leading-none text-slate-500 shadow-sm transition group-hover:border-slate-300 group-hover:text-slate-800;
+    @apply flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-base leading-none text-slate-500 shadow-sm transition;
+  }
+
+  .nav-back:hover .nav-back__chevron {
+    @apply border-slate-300 text-slate-800;
   }
 
   #actions {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -390,8 +390,6 @@
     @apply gap-0 px-4 py-2;
   }
 
-  /* FIX 2: Allow actions to wrap below content on narrow screens so the card
-     never clips. Items stay top-aligned so long names don't misalign buttons. */
   .session-history-card.volunteer-row {
     @apply py-4 flex-wrap items-start;
   }
@@ -408,7 +406,6 @@
     @apply m-0 mt-2 text-sm leading-snug text-gray-600;
   }
 
-  /* FIX 3: Participants table — column separators stop name/email from smushing. */
   .sessions-participants-wrap {
     @apply mt-2;
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,6 +43,20 @@ class ApplicationController < ActionController::Base
     AttendanceMailer.application_queued(volunteer.email).deliver_now
   end
 
+  def complete_info_session_check_in_success!(volunteer:, information_session:)
+    volunteer.finalize_check_in_for_session!(information_session, user: current_user)
+    deliver_application_queued_email!(volunteer)
+    redirect_to volunteer_path(volunteer), notice: "Application queued for #{volunteer.full_name}"
+  end
+
+  def redirect_if_already_attended_for_session!(volunteer:, information_session:, registration: nil)
+    registration ||= SessionRegistration.find_by(volunteer: volunteer, information_session: information_session)
+    return false unless registration&.attended?
+
+    redirect_to volunteer_path(volunteer), notice: "#{volunteer.full_name} is already checked in for this session."
+    true
+  end
+
   def current_user
     return @current_user if defined?(@current_user)
     # In the browser flow, we set `session[:user_id]` in `SessionsController`.

--- a/app/controllers/information_sessions_controller.rb
+++ b/app/controllers/information_sessions_controller.rb
@@ -1,42 +1,64 @@
 class InformationSessionsController < ApplicationController
+  SESSIONS_PER_PAGE = 10
+
+  before_action :set_information_sessions_list_filters,
+    only: [:index, :new, :create, :edit, :sign_in, :update, :destroy, :remove_attendee]
+
   def index
-    @information_sessions = InformationSession.all
+    rel = InformationSession.includes(:created_by_user).all
 
     if params[:start_date].present?
-      start_date = Date.strptime(params[:start_date], "%m/%d/%y") rescue Date.parse(params[:start_date])
-      @information_sessions = @information_sessions.where("scheduled_at >= ?", start_date.beginning_of_day)
+      start_date = parsed_list_filter_date(params[:start_date])
+      rel = rel.where("scheduled_at >= ?", start_date.beginning_of_day) if start_date
     end
 
     if params[:end_date].present?
-      end_date = Date.strptime(params[:end_date], "%m/%d/%y") rescue Date.parse(params[:end_date])
-      @information_sessions = @information_sessions.where("scheduled_at <= ?", end_date.end_of_day)
+      end_date = parsed_list_filter_date(params[:end_date])
+      rel = rel.where("scheduled_at <= ?", end_date.end_of_day) if end_date
     end
 
     if params[:location].present?
-      @information_sessions = @information_sessions.where(location: params[:location])
+      rel = rel.where(location: params[:location])
     end
 
-    if params[:upcoming_past] == "Past"
-      @information_sessions = @information_sessions.where("scheduled_at < ?", Time.current)
-    elsif params[:upcoming_past] == "Upcoming" || params[:upcoming_past].blank?
-      @information_sessions = @information_sessions.where("scheduled_at >= ?", Time.current)
+    time_filter = params[:upcoming_past].presence || "All"
+
+    case time_filter
+    when "Past"
+      rel = rel.where("scheduled_at < ?", Time.current)
+    when "Upcoming"
+      rel = rel.where("scheduled_at >= ?", Time.current)
     end
+
+    rel = rel.order(created_at: :desc)
+
+    total = rel.count
+    max_page = [ (total.to_f / SESSIONS_PER_PAGE).ceil, 1 ].max
+    page = [ params[:page].to_i, 1 ].max
+    page = [ page, max_page ].min
+
+    @information_sessions = rel.offset((page - 1) * SESSIONS_PER_PAGE).limit(SESSIONS_PER_PAGE)
+    @sessions_page = page
+    @sessions_total_pages = max_page
+    @sessions_total_count = total
   end
 
   def new
     @information_session = InformationSession.new
   end
 
-def create
-  @information_session = InformationSession.new(information_session_params)
+  def create
+    @information_session = InformationSession.new(information_session_params)
+    @information_session.created_by_user = current_user
 
-  if @information_session.save
-    redirect_to information_sessions_path, notice: "Information session was successfully created."
-  else
-    flash.now[:alert] = "Please fix the errors below."
-    render :new
+    if @information_session.save
+      redirect_to information_sessions_path(**list_filter_params_compact.except(:page)),
+        notice: "Information session was successfully created."
+    else
+      flash.now[:alert] = "Please fix the errors below."
+      render :new
+    end
   end
-end
 
   def edit
     @information_session = InformationSession.find(params[:id])
@@ -46,7 +68,7 @@ end
     @information_session = InformationSession.find(params[:id])
 
     if @information_session.update(information_session_params)
-      redirect_to edit_information_session_path(@information_session)
+      redirect_to edit_information_session_path(@information_session, **list_filter_params_compact)
     else
       flash.now[:alert] = "Please fix the errors below."
       render :edit
@@ -60,7 +82,6 @@ end
   def check_in
     @session = InformationSession.find(params[:id])
 
-    # Registered volunteers submit with `volunteer_id`.
     if params[:volunteer_id].present?
       volunteer = Volunteer.find(params[:volunteer_id])
 
@@ -69,28 +90,26 @@ end
         information_session: @session
       )
 
-      volunteer.finalize_check_in_for_session!(@session, user: current_user)
-      deliver_application_queued_email!(volunteer)
-
-      redirect_to volunteer_path(volunteer), notice: "Application queued for #{volunteer.full_name}"
+      complete_info_session_check_in_success!(volunteer: volunteer, information_session: @session)
       return
     end
 
-    # Walk-in volunteers submit with `email`.
     email = params[:email].to_s.strip.downcase
     volunteer = Volunteer.find_by(email: email)
 
-    registration = volunteer && SessionRegistration.find_by(
-      volunteer: volunteer,
-      information_session: @session
-    )
+    registration =
+      if volunteer
+        SessionRegistration.find_by(volunteer: volunteer, information_session: @session)
+      end
 
-    if registration&.attended?
-      redirect_to volunteer_path(volunteer), notice: "#{volunteer.full_name} is already checked in for this session."
+    if redirect_if_already_attended_for_session!(
+      volunteer: volunteer,
+      information_session: @session,
+      registration: registration
+    )
       return
     end
 
-    # Not on the session list (or not registered for this session): inquiry at check-in per meeting notes.
     if volunteer.nil? || registration.nil? || !registration.registered?
       redirect_to new_inquiry_form_path(
         information_session_id: @session.id,
@@ -99,10 +118,7 @@ end
       return
     end
 
-    volunteer.finalize_check_in_for_session!(@session, user: current_user)
-    deliver_application_queued_email!(volunteer)
-
-    redirect_to volunteer_path(volunteer), notice: "Application queued for #{volunteer.full_name}"
+    complete_info_session_check_in_success!(volunteer: volunteer, information_session: @session)
   end
 
   def remove_attendee
@@ -111,25 +127,41 @@ end
     registration = SessionRegistration.find_by!(information_session: session, volunteer: volunteer)
     registration.destroy
 
-    redirect_to edit_information_session_path(session), notice: "#{volunteer.full_name} removed!"
+    redirect_to edit_information_session_path(session, **list_filter_params_compact), notice: "#{volunteer.full_name} removed!"
   end
 
   def destroy
     @information_session = InformationSession.find(params[:id])
     @information_session.destroy
-    redirect_to information_sessions_path, notice: "Information session was successfully deleted."
+    redirect_to information_sessions_path(**list_filter_params_compact), notice: "Information session was successfully deleted."
   end
 
   private
+
+  def set_information_sessions_list_filters
+    @list_filter_params = params.permit(:start_date, :end_date, :location, :upcoming_past, :page).to_h.symbolize_keys
+  end
+
+  def list_filter_params_compact
+    params.permit(:start_date, :end_date, :location, :upcoming_past, :page).to_h.symbolize_keys.compact_blank
+  end
+
+  def parsed_list_filter_date(raw)
+    return nil if raw.blank?
+
+    Date.strptime(raw, "%m/%d/%y") rescue Date.parse(raw)
+  end
 
   def information_session_params
     p = params.require(:information_session).permit(
       :name,
       :scheduled_at,
-      :location
+      :location,
+      :capacity,
+      :zoom_link
     )
     if p[:scheduled_at].present?
-        p[:scheduled_at] = Time.zone.parse(p[:scheduled_at])
+      p[:scheduled_at] = Time.zone.parse(p[:scheduled_at])
     end
 
     p

--- a/app/controllers/information_sessions_controller.rb
+++ b/app/controllers/information_sessions_controller.rb
@@ -2,7 +2,7 @@ class InformationSessionsController < ApplicationController
   SESSIONS_PER_PAGE = 10
 
   before_action :set_information_sessions_list_filters,
-    only: [:index, :new, :create, :edit, :sign_in, :update, :destroy, :remove_attendee]
+    only: [ :index, :new, :create, :edit, :sign_in, :update, :destroy, :remove_attendee ]
 
   def index
     rel = InformationSession.includes(:created_by_user).all

--- a/app/controllers/inquiry_form_controller.rb
+++ b/app/controllers/inquiry_form_controller.rb
@@ -37,15 +37,15 @@ class InquiryFormController < ApplicationController
 
       if volunteer
         registration = SessionRegistration.find_by(volunteer: volunteer, information_session: info_session)
-        if registration&.attended?
-          redirect_to volunteer_path(volunteer), notice: "#{volunteer.full_name} is already checked in for this session."
+        if redirect_if_already_attended_for_session!(
+          volunteer: volunteer,
+          information_session: info_session,
+          registration: registration
+        )
           return
         end
 
-        volunteer.finalize_check_in_for_session!(info_session, user: current_user)
-        deliver_application_queued_email!(volunteer)
-
-        redirect_to volunteer_path(volunteer), notice: "Application queued for #{volunteer.full_name}"
+        complete_info_session_check_in_success!(volunteer: volunteer, information_session: info_session)
         return
       end
 
@@ -75,10 +75,7 @@ class InquiryFormController < ApplicationController
         processed_at: Time.current
       )
 
-      volunteer.finalize_check_in_for_session!(info_session, user: current_user)
-      deliver_application_queued_email!(volunteer)
-
-      redirect_to volunteer_path(volunteer), notice: "Application queued for #{volunteer.full_name}"
+      complete_info_session_check_in_success!(volunteer: volunteer, information_session: info_session)
       return
     end
 

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -11,7 +11,7 @@ class VolunteersController < ApplicationController
   def show
     filter = params[:filter].to_s
     @timeline_filter = filter.presence || "all"
-    @timeline_entries = timeline_entries(@volunteer, filter: @timeline_filter)
+    @timeline_entries = VolunteerTimeline.entries_for(@volunteer, filter: @timeline_filter)
   end
 
   def sms
@@ -35,7 +35,7 @@ class VolunteersController < ApplicationController
 
   def add_note
     volunteer = Volunteer.find(params[:id])
-    note = volunteer.notes.create(
+    note = volunteer.add_staff_note(
       content: params[:note].to_s,
       user: current_user,
       note_type: :general
@@ -63,7 +63,7 @@ class VolunteersController < ApplicationController
     end
 
     volunteers.each do |volunteer|
-      volunteer.notes.create(content: note_content, user: current_user, note_type: :general)
+      volunteer.add_staff_note(content: note_content, user: current_user, note_type: :general)
     end
 
     redirect_to volunteers_path, notice: "Note added to #{volunteers.count} volunteers"
@@ -91,50 +91,6 @@ class VolunteersController < ApplicationController
 
   def set_volunteer
     @volunteer = Volunteer.find(params[:id])
-  end
-
-  def timeline_entries(volunteer, filter:)
-    entries = []
-    notes = volunteer.notes.includes(:user)
-    communications = volunteer.communications
-
-    notes.each do |note|
-      entries << {
-        kind: :note,
-        time: note.created_at,
-        text: note.content,
-        byline: note.user&.full_name.to_s,
-        note: note
-      }
-    end
-
-    communications.each do |comm|
-      entries << {
-        kind: comm.communication_type.to_sym,
-        time: comm.sent_at || comm.created_at,
-        text: comm.body.to_s,
-        status: comm.status
-      }
-    end
-
-    volunteer.session_registrations.includes(:information_session).each do |registration|
-      next unless registration.information_session
-
-      entries << {
-        kind: :info_session,
-        time: registration.created_at,
-        text: "Info session: #{registration.information_session.name}"
-      }
-    end
-
-    filtered = case filter
-    when "notes"
-      entries.select { |entry| entry[:kind] == :note }
-    else
-      entries
-    end
-
-    filtered.sort_by { |entry| entry[:time] || Time.at(0) }.reverse
   end
 
   def ensure_list_volunteer(full_name)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,14 @@
 module ApplicationHelper
+  # Up-level navigation: chevron + label (dashboard-style “return to parent” link).
+  def back_nav_link(path, label)
+    link_to path, class: "nav-back" do
+      safe_join([
+        tag.span("←", class: "nav-back__chevron", aria: { hidden: true }),
+        tag.span(label)
+      ])
+    end
+  end
+
   # Bust browser caches for static files in /public (favicons) when the file changes.
   def public_asset_version(relative_filename)
     path = Rails.root.join("public", relative_filename.to_s.delete_prefix("/"))

--- a/app/helpers/information_sessions_helper.rb
+++ b/app/helpers/information_sessions_helper.rb
@@ -10,9 +10,9 @@ module InformationSessionsHelper
   end
 
   def information_session_location_select_options(session)
-    choices = InformationSession::LOCATION_CHOICES.map { |l| [l, l] }
+    choices = InformationSession::LOCATION_CHOICES.map { |l| [ l, l ] }
     if session.location.present? && InformationSession::LOCATION_CHOICES.exclude?(session.location)
-      choices.unshift([session.location, session.location])
+      choices.unshift([ session.location, session.location ])
     end
     choices
   end

--- a/app/helpers/information_sessions_helper.rb
+++ b/app/helpers/information_sessions_helper.rb
@@ -1,0 +1,28 @@
+module InformationSessionsHelper
+  FILTER_PARAM_KEYS = %i[start_date end_date location upcoming_past page].freeze
+
+  def information_sessions_filter_params
+    params.permit(*FILTER_PARAM_KEYS).to_h.symbolize_keys
+  end
+
+  def information_sessions_path_with_filters(**extra)
+    information_sessions_path(**information_sessions_filter_params.compact_blank.merge(extra))
+  end
+
+  def information_session_location_select_options(session)
+    choices = InformationSession::LOCATION_CHOICES.map { |l| [l, l] }
+    if session.location.present? && InformationSession::LOCATION_CHOICES.exclude?(session.location)
+      choices.unshift([session.location, session.location])
+    end
+    choices
+  end
+
+  def information_session_creator_line(session)
+    user = session.created_by_user
+    if user
+      "Created by: #{user.display_name} (#{user.email})"
+    else
+      "Created by: Unknown"
+    end
+  end
+end

--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -28,7 +28,7 @@ class Communication < ApplicationRecord
     prev, curr = saved_change_to_sent_at
     return if prev.present? || curr.blank?
 
-    volunteer.notes.create!(
+    volunteer.add_staff_note!(
       user: sent_by_user,
       note_type: :communication,
       content: "Reminder #{communication_type} sent at #{sent_at.strftime('%m/%d/%Y %H:%M')}"

--- a/app/models/information_session.rb
+++ b/app/models/information_session.rb
@@ -1,7 +1,7 @@
 class InformationSession < ApplicationRecord
   enum :session_type, { in_person: 0, virtual: 1 }
 
-  LOCATION_CHOICES = ["415 Hamburg Turnpike", "Zoom"].freeze
+  LOCATION_CHOICES = [ "415 Hamburg Turnpike", "Zoom" ].freeze
 
   attribute :capacity, :integer, default: 10
 
@@ -16,7 +16,7 @@ class InformationSession < ApplicationRecord
   validates :zoom_link,
     presence: true,
     format: {
-      with: /\Ahttps?:\/\/.+/i,
+      with: /\Ahttps?:\/\/.+\z/i,
       message: "must be a URL starting with http:// or https://"
     },
     if: :zoom_location?

--- a/app/models/information_session.rb
+++ b/app/models/information_session.rb
@@ -1,11 +1,29 @@
 class InformationSession < ApplicationRecord
   enum :session_type, { in_person: 0, virtual: 1 }
 
+  LOCATION_CHOICES = ["415 Hamburg Turnpike", "Zoom"].freeze
+
+  attribute :capacity, :integer, default: 10
+
+  belongs_to :created_by_user, class_name: "User", optional: true
+
   has_many :session_registrations, dependent: :destroy
   has_many :volunteers, through: :session_registrations
 
   validates :scheduled_at, presence: { message: "Must include date." }
   validate :scheduled_at_must_be_in_the_future, if: -> { scheduled_at.present? }
+  validates :location, presence: true, inclusion: { in: LOCATION_CHOICES }
+  validates :zoom_link,
+    presence: true,
+    format: {
+      with: /\Ahttps?:\/\/.+/i,
+      message: "must be a URL starting with http:// or https://"
+    },
+    if: :zoom_location?
+
+  before_validation :sync_session_type_from_location
+  before_validation :ensure_capacity_default
+  before_save :clear_zoom_link_unless_zoom
 
   scope :active, -> { where(active: true) }
   scope :upcoming, -> { where("scheduled_at > ?", Time.current).order(:scheduled_at) }
@@ -24,5 +42,21 @@ class InformationSession < ApplicationRecord
     if scheduled_at < Time.current
       errors.add(:scheduled_at, "Information session must be in the future")
     end
+  end
+
+  def zoom_location?
+    location == "Zoom"
+  end
+
+  def sync_session_type_from_location
+    self.session_type = zoom_location? ? :virtual : :in_person
+  end
+
+  def clear_zoom_link_unless_zoom
+    self.zoom_link = nil unless zoom_location?
+  end
+
+  def ensure_capacity_default
+    self.capacity = 10 if capacity.blank?
   end
 end

--- a/app/models/session_registration.rb
+++ b/app/models/session_registration.rb
@@ -7,9 +7,4 @@ class SessionRegistration < ApplicationRecord
   validates :volunteer_id, uniqueness: { scope: :information_session_id, message: "already registered for this session" }
 
   scope :active, -> { where(status: [ :registered, :attended ]) }
-
-  # User Story 9 step defs expect `registration.attended` (not `attended?`).
-  def attended
-    attended?
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,11 @@ class User < ApplicationRecord
   has_many :notes, dependent: :destroy
   has_many :communications, foreign_key: :sent_by_user_id, dependent: :nullify
   has_many :status_changes, dependent: :nullify
+  has_many :information_sessions_created,
+    class_name: "InformationSession",
+    foreign_key: :created_by_user_id,
+    inverse_of: :created_by_user,
+    dependent: :nullify
 
   validates :email, presence: true, uniqueness: true
 

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -33,13 +33,10 @@ class Volunteer < ApplicationRecord
     first_session_attended_at.present?
   end
 
-  # User Story 9 expects a `status` method that reflects attendance.
-  # We keep funnel stage tracking in `current_funnel_stage`, but expose an
-  # attendance-focused status for the sign-in flow.
   def status
     return :attended_session if attended_session?
 
-    current_funnel_stage
+    current_funnel_stage.to_sym
   end
 
   def can_reactivate?
@@ -84,8 +81,6 @@ class Volunteer < ApplicationRecord
     )
   end
 
-  # Info session check-in: mark registration attended, set first-session time, advance to eligible.
-  # Application is sent separately (staff action or automation); see +send_application+.
   def finalize_check_in_for_session!(information_session, user:)
     registration = SessionRegistration.find_or_initialize_by(
       volunteer: self,

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -50,6 +50,15 @@ class Volunteer < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  # Staff-authored or system-captured notes (profile form, bulk list, communication callbacks).
+  def add_staff_note(content:, user:, note_type: :general)
+    notes.create(content: content.to_s, user: user, note_type: note_type)
+  end
+
+  def add_staff_note!(content:, user:, note_type: :general)
+    notes.create!(content: content.to_s, user: user, note_type: note_type)
+  end
+
   # Single label for the profile "Current status" block (matches user-facing copy elsewhere).
   def profile_status_label
     if applied?

--- a/app/services/volunteer_timeline.rb
+++ b/app/services/volunteer_timeline.rb
@@ -60,6 +60,18 @@ class VolunteerTimeline
       }
     end
 
+    @volunteer.scheduled_reminders.includes(:communication_template).each do |reminder|
+      template = reminder.communication_template
+      next unless template
+
+      anchor = reminder.sent_at.presence || reminder.scheduled_for.presence || reminder.created_at
+      entries << {
+        kind: :scheduled_reminder,
+        time: anchor,
+        text: "#{template.name} — scheduled reminder for #{anchor.in_time_zone.strftime('%m/%d/%Y %H:%M')}"
+      }
+    end
+
     entries
   end
 end

--- a/app/services/volunteer_timeline.rb
+++ b/app/services/volunteer_timeline.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Builds the consolidated volunteer profile timeline (notes, communications, info sessions)
+# used on the volunteer show page. Extracted from VolunteersController for clarity and testing.
+class VolunteerTimeline
+  FILTER_ALL = "all"
+  FILTER_NOTES = "notes"
+
+  def self.entries_for(volunteer, filter:)
+    new(volunteer, filter: filter).entries
+  end
+
+  def initialize(volunteer, filter:)
+    @volunteer = volunteer
+    @filter = filter.to_s.presence || FILTER_ALL
+  end
+
+  def entries
+    filtered = case @filter
+    when FILTER_NOTES
+      raw_entries.select { |entry| entry[:kind] == :note }
+    else
+      raw_entries
+    end
+
+    filtered.sort_by { |entry| entry[:time] || Time.at(0) }.reverse
+  end
+
+  private
+
+  def raw_entries
+    entries = []
+
+    @volunteer.notes.includes(:user).each do |note|
+      entries << {
+        kind: :note,
+        time: note.created_at,
+        text: note.content,
+        byline: note.user&.full_name.to_s,
+        note: note
+      }
+    end
+
+    @volunteer.communications.each do |comm|
+      entries << {
+        kind: comm.communication_type.to_sym,
+        time: comm.sent_at || comm.created_at,
+        text: comm.body.to_s,
+        status: comm.status
+      }
+    end
+
+    @volunteer.session_registrations.includes(:information_session).each do |registration|
+      next unless registration.information_session
+
+      entries << {
+        kind: :info_session,
+        time: registration.created_at,
+        text: "Info session: #{registration.information_session.name}"
+      }
+    end
+
+    entries
+  end
+end

--- a/app/views/information_sessions/_session_fields.html.erb
+++ b/app/views/information_sessions/_session_fields.html.erb
@@ -1,0 +1,40 @@
+<div class="form-row">
+  <%= f.label :name %>
+  <%= f.text_field :name, class: "input-large" %>
+</div>
+
+<div class="form-row">
+  <%= f.label :scheduled_at, "Date & Time" %>
+  <%= f.datetime_local_field :scheduled_at,
+      value: f.object.scheduled_at&.strftime("%Y-%m-%dT%H:%M"),
+      class: "input-large" %>
+</div>
+
+<div class="form-row">
+  <%= f.label :location, "Location" %>
+  <%= f.select :location,
+      options_for_select(
+        information_session_location_select_options(f.object),
+        selected: f.object.location
+      ),
+      {},
+      {
+        class: "input-large",
+        id: "information_session_location",
+        onchange: "document.getElementById('session-zoom-link-row').hidden = (this.value !== 'Zoom')"
+      } %>
+</div>
+
+<div class="form-row" id="session-zoom-link-row" <%= "hidden" unless f.object.zoom_location? %>>
+  <%= f.label :zoom_link, "Zoom link" %>
+  <%= f.url_field :zoom_link, class: "input-large", placeholder: "https://..." %>
+</div>
+
+<div class="form-row">
+  <%= f.label :capacity %>
+  <%= f.number_field :capacity,
+      value: (f.object.read_attribute(:capacity) || 10),
+      min: 1,
+      step: 1,
+      class: "input-large" %>
+</div>

--- a/app/views/information_sessions/edit.html.erb
+++ b/app/views/information_sessions/edit.html.erb
@@ -1,55 +1,67 @@
-<%= link_to "Back", information_sessions_path, class: "button" %>
-<h1>Edit Information Session</h1>
+<main class="volunteer-page">
+  <nav class="page-nav page-nav--back" aria-label="Back">
+    <%= back_nav_link information_sessions_path(@list_filter_params.compact_blank), "Back to information sessions" %>
+  </nav>
 
-<%= form_with model: @information_session, local: true do |f| %>
-  <div>
-    <%= f.label :name %><br>
-    <%= f.text_field :name %>
-  </div>
+  <h1 class="page-title">Edit Information Session</h1>
 
-  <div>
-    <%= f.label :scheduled_at, "Date & Time" %><br>
-    <%= f.datetime_local_field :scheduled_at, value: @information_session.scheduled_at.strftime("%Y-%m-%dT%H:%M") %>
-  </div>
+  <section class="card status-panel">
+    <% if @information_session.errors.any? %>
+      <div class="errors" role="alert">
+        <% @information_session.errors.full_messages.each do |msg| %>
+          <p><%= msg %></p>
+        <% end %>
+      </div>
+    <% end %>
 
-  <div>
-    <%= f.label :location %><br>
-    <%= f.text_field :location %>
-  </div>
-
-  <div>
-    <%= f.label :capacity %><br>
-    <%= f.number_field :capacity %>
-  </div>
-
-  <div>
-    <%= f.submit "Save Changes" %>
-  </div>
-<% end %>
-
-<div>
-  <h3>Participants</h3>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Email</th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @information_session.volunteers.each do |volunteer| %>
-        <tr id="attendee-<%= volunteer.id %>">
-          <td><%= volunteer.full_name %></td>
-          <td><%= volunteer.email %></td>
-        <td>
-          <%= button_to "Remove",
-              remove_attendee_information_session_path(@information_session, volunteer_id: volunteer.id),
-              method: :delete,
-              onclick: "return confirm('Are you sure you want to remove #{volunteer.full_name}?')" %>
-        </td>
-        </tr>
+    <%= form_with model: @information_session, local: true, html: { class: "status-update-form information-session-form" } do |f| %>
+      <% (@list_filter_params || {}).each do |key, val| %>
+        <% next if val.blank? %>
+        <%= hidden_field_tag key, val %>
       <% end %>
-    </tbody>
-  </table>
-</div>
+      <%= render partial: "session_fields", locals: { f: f } %>
+
+      <div class="form-row">
+        <%= f.submit "Save Changes", class: "button-primary sessions-toolbar-btn" %>
+      </div>
+    <% end %>
+  </section>
+
+  <section class="card status-panel">
+    <h2 class="section-heading">Participants</h2>
+    <div class="sessions-table-wrap sessions-participants-wrap">
+      <table class="sessions-table sessions-participants-table">
+        <colgroup>
+          <col class="sessions-participants-col-name">
+          <col class="sessions-participants-col-email">
+          <col class="sessions-participants-col-actions">
+        </colgroup>
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Email</th>
+            <th scope="col" class="text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @information_session.volunteers.each do |volunteer| %>
+            <tr id="attendee-<%= volunteer.id %>">
+              <td class="sessions-participants-name"><%= volunteer.full_name %></td>
+              <td class="sessions-participants-email"><%= volunteer.email %></td>
+              <td class="sessions-actions sessions-participants-actions">
+                <%= button_to "Remove",
+                    remove_attendee_information_session_path(
+                      @information_session,
+                      { volunteer_id: volunteer.id }.merge(@list_filter_params.compact_blank)
+                    ),
+                    method: :delete,
+                    class: "btn-delete sessions-toolbar-btn",
+                    form: { data: { turbo_confirm: "Are you sure you want to remove #{volunteer.full_name}?" } } %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</main>

--- a/app/views/information_sessions/index.html.erb
+++ b/app/views/information_sessions/index.html.erb
@@ -1,62 +1,125 @@
-<h1>Information Sessions</h1>
-<div class="filterBox">
-  <%= form_with url: information_sessions_path, method: :get, local: true do |f| %>
-    <div class="filterFields">
-      <div class="filterField">
-        <%= f.label :start_date, "Start Date" %>
-        <%= f.date_field :start_date, value: params[:start_date] %>
-      </div>
+<main class="volunteer-page sessions-index flex flex-col gap-6">
+  <header class="sessions-page-header">
+    <h1 class="page-title sessions-index__title">Information Sessions</h1>
+  </header>
 
-      <div class="filterField">
-        <%= f.label :end_date, "End Date" %>
-        <%= f.date_field :end_date, value: params[:end_date] %>
+  <section class="card sessions-filter-card" aria-label="Filter sessions">
+    <%= form_with url: information_sessions_path, method: :get, local: true do |f| %>
+      <div class="sessions-filter-grid">
+        <div class="form-row">
+          <%= f.label :start_date, "Start Date" %>
+          <%= f.date_field :start_date, value: params[:start_date], class: "input-large" %>
+        </div>
+        <div class="form-row">
+          <%= f.label :end_date, "End Date" %>
+          <%= f.date_field :end_date, value: params[:end_date], class: "input-large" %>
+        </div>
+        <div class="form-row">
+          <%= f.label :location, "Location" %>
+          <%= f.select :location,
+              options_for_select(
+                [["415 Hamburg Turnpike", "415 Hamburg Turnpike"], ["Zoom", "Zoom"]],
+                selected: params[:location]
+              ),
+              { include_blank: "All locations" },
+              { class: "input-large" } %>
+        </div>
+        <div class="form-row">
+          <%= f.label :upcoming_past, "Time range" %>
+          <%= f.select :upcoming_past,
+              options_for_select(
+                [
+                  ["All sessions", "All"],
+                  ["Upcoming only", "Upcoming"],
+                  ["Past only", "Past"]
+                ],
+                selected: params[:upcoming_past].presence || "All"
+              ),
+              {},
+              { class: "input-large" } %>
+        </div>
+        <div class="sessions-filter-actions">
+          <%= f.button "Filter", type: "submit", class: "button-primary" %>
+          <%= link_to "Clear filters", information_sessions_path, class: "button-link" %>
+        </div>
       </div>
+    <% end %>
+  </section>
 
-      <div class="filterField">
-        <%= f.label :location, "Location" %>
-        <%= f.select :location, options_for_select([['415 Hamburg Turnpike', '415 Hamburg Turnpike'], ['Zoom', 'Zoom']], selected: params[:location]), include_blank: "All Locations" %>
-      </div>
+  <div class="sessions-page-create">
+    <%= link_to "Create New Information Session",
+        new_information_session_path(information_sessions_filter_params.compact_blank),
+        class: "button-primary sessions-page-create__btn" %>
+  </div>
+  <% sessions = @information_sessions || [] %>
+  <% if sessions.empty? %>
+    <section class="sessions-empty" aria-live="polite">
+      <h2 class="subsection-heading">No sessions found</h2>
+      <p class="subtle">Try different dates or location, or use the Clear filters control in the section above.</p>
+    </section>
+  <% else %>
+    <% filter_opts = information_sessions_filter_params.compact_blank %>
+    <h2 class="section-heading sessions-history-heading">Information Session History</h2>
+    <section id="information-session-list" class="card volunteer-list sessions-history-list" aria-label="Information sessions">
+      <% sessions.each do |session| %>
+        <% tz = session.scheduled_at.in_time_zone %>
+        <% date_part = tz.strftime("%b %d, %Y") %>
+        <% time_part = tz.strftime("%I:%M %p") %>
+        <article
+          data-session-list-item
+          class="volunteer-row session-history-card">
+          <div class="volunteer-meta min-w-0">
+            <div class="volunteer-name"><%= session.name %></div>
+            <div class="volunteer-subtext session-history-meta">
+              <span><%= session.location %></span>
+              <span>
+                <time datetime="<%= tz.iso8601 %>">
+                  <%= date_part %> <%= time_part %>
+                </time>
+              </span>
+            </div>
+            <p class="session-history-created-by"><%= information_session_creator_line(session) %></p>
+          </div>
+          <div class="volunteer-actions sessions-session-actions">
+            <%= link_to "Sign in", sign_in_information_session_path(session, filter_opts), class: "button-link" %>
+            <%= link_to "Edit", edit_information_session_path(session, filter_opts), class: "button-link" %>
+            <%= button_to "Delete",
+                information_session_path(session, filter_opts),
+                method: :delete,
+                class: "btn-delete",
+                form: {
+                  class: "inline m-0",
+                  data: { turbo_confirm: "Delete \"#{session.name}\"? This cannot be undone." }
+                } %>
+          </div>
+        </article>
+      <% end %>
+    </section>
 
-      <div class="filterField">
-        <%= f.label :upcoming_past, "Upcoming/Past" %>
-        <%= f.select :upcoming_past, 
-            options_for_select([['Upcoming', 'Upcoming'], ['Past', 'Past']], selected: params[:upcoming_past] || 'Upcoming'),
-            {} %>
-      </div>
-
-      <div class="filterField">
-        <%= f.submit "Filter" %>
-      </div>
-    </div>
+    <% if @sessions_total_pages.to_i > 1 %>
+      <nav class="sessions-pagination card" aria-label="Pagination">
+        <% if @sessions_page > 1 %>
+          <%= link_to "Previous",
+              information_sessions_path_with_filters(page: @sessions_page - 1),
+              class: "button-link sessions-pagination__control" %>
+        <% end %>
+        <ol class="sessions-pagination__pages">
+          <% (1..@sessions_total_pages).each do |n| %>
+            <li>
+              <% if n == @sessions_page %>
+                <span class="sessions-pagination__current" aria-current="page"><%= n %></span>
+              <% else %>
+                <%= link_to n, information_sessions_path_with_filters(page: n), class: "button-link sessions-pagination__link" %>
+              <% end %>
+            </li>
+          <% end %>
+        </ol>
+        <% if @sessions_page < @sessions_total_pages %>
+          <%= link_to "Next",
+              information_sessions_path_with_filters(page: @sessions_page + 1),
+              class: "button-link sessions-pagination__control" %>
+        <% end %>
+      </nav>
+    <% end %>
   <% end %>
-</div>
-<div class="dataList">
-    <table>
-        <thead>
-            <tr>
-            <th>Name</th>
-            <th>Date</th>
-            <th>Time</th>
-            <th>Location</th>
-            </tr>
-        </thead>
-        <tbody>
-            <% (@information_sessions || []).each do |session| %>
-            <tr>
-                <td><%= session.name %></td>
-                <td><%= session.scheduled_at.in_time_zone.strftime("%b %d, %Y") %></td>
-                <td><%= session.scheduled_at.in_time_zone.strftime("%I:%M %p") %></td>
-                <td><%= session.location %></td>
-                <td>
-                  <%= link_to "Edit", edit_information_session_path(session), class: "btn btn-sm btn-primary" %>
-                  <%= button_to "Delete", information_session_path(session),
-                                method: :delete,
-                                data: { turbo_confirm: "Are you sure you want to delete this session?" },
-                                onclick: "return confirm('Are you sure you want to remove #{session.name}?')" %>
-                </td>
-            </tr>
-            <% end %>
-        </tbody>
-    </table>
-</div>
-<%= link_to "Create New", new_information_session_path %>
+</main>

--- a/app/views/information_sessions/new.html.erb
+++ b/app/views/information_sessions/new.html.erb
@@ -1,35 +1,29 @@
-<div>
-    <h1>New Information Session</h1>
-    <div class="createNewBox">
-        <%= form_with model: @information_session, local: true do |f| %>
-            <div class="filterFields">
-                <div class="filterField">
-                    <%= f.label :name, "Name" %>
-                    <%= f.text_field :name %>
-                </div>
+<main class="volunteer-page">
+  <nav class="page-nav page-nav--back" aria-label="Back">
+    <%= back_nav_link information_sessions_path(@list_filter_params.compact_blank), "Back to information sessions" %>
+  </nav>
 
-                <div class="filterField">
-                    <%= f.label :scheduled_at, "Date & Time" %>
-                    <%= f.datetime_local_field :scheduled_at %>
-                </div>
+  <h1 class="page-title">New Information Session</h1>
 
-                <div class="filterField">
-                    <%= f.label :location, "Location" %>
-                    <%= f.select :location, options_for_select([['415 Hamburg Turnpike', '415 Hamburg Turnpike'], ['Zoom', 'Zoom']], selected: params[:location]), include_blank: "All Locations" %>
-                </div>
-
-                <div class="filterField">
-                    <%= f.submit "Create Event" %>
-                </div>
-            </div>
+  <section class="card">
+    <% if @information_session.errors.any? %>
+      <div class="errors" role="alert">
+        <% @information_session.errors.full_messages.each do |msg| %>
+          <p><%= msg %></p>
         <% end %>
-    </div>
-    
-</div>
-<% if @information_session.errors.any? %>
-  <div class="errors">
-    <% @information_session.errors.full_messages.each do |msg| %>
-      <p><%= msg %></p>
+      </div>
     <% end %>
-  </div>
-<% end %>
+
+    <%= form_with model: @information_session, local: true, html: { class: "status-update-form information-session-form" } do |f| %>
+      <% (@list_filter_params || {}).each do |key, val| %>
+        <% next if val.blank? %>
+        <%= hidden_field_tag key, val %>
+      <% end %>
+      <%= render partial: "session_fields", locals: { f: f } %>
+
+      <div class="form-row">
+        <%= f.submit "Create Event", class: "button-primary sessions-toolbar-btn" %>
+      </div>
+    <% end %>
+  </section>
+</main>

--- a/app/views/information_sessions/sign_in.html.erb
+++ b/app/views/information_sessions/sign_in.html.erb
@@ -1,26 +1,44 @@
-<h1>Sign-In: <%= @session.name %></h1>
+<main class="volunteer-page">
+  <nav class="page-nav page-nav--back" aria-label="Back">
+    <%= back_nav_link information_sessions_path(@list_filter_params.compact_blank), "Back to information sessions" %>
+  </nav>
 
-<section id="walkin-sign-in" class="walkin-sign-in">
-  <h2>Walk-in sign in</h2>
-  <%= form_with url: check_in_information_session_path(@session), method: :post do %>
-    <div>
-      <label for="email">Email</label>
-      <input type="email" id="email" name="email" />
-    </div>
-    <button type="submit">Check in walk-in</button>
-  <% end %>
-</section>
+  <h1 class="page-title">Sign-In: <%= @session.name %></h1>
 
-<% @session.session_registrations.includes(:volunteer).each do |registration| %>
-  <div class="volunteer-registration">
-    <span><%= registration.volunteer.full_name %></span>
-    <span><%= registration.volunteer.current_funnel_stage.humanize %></span>
-
-    <% unless registration.attended? %>
-      <%= form_with url: check_in_information_session_path(@session), method: :post do %>
-        <input type="hidden" name="volunteer_id" value="<%= registration.volunteer.id %>">
-        <button type="submit">Check in <%= registration.volunteer.full_name %></button>
-      <% end %>
+  <section id="walkin-sign-in" class="card walkin-sign-in">
+    <h2 class="section-heading">Walk-in sign in</h2>
+    <%= form_with url: check_in_information_session_path(@session), method: :post, html: { class: "status-update-form" } do %>
+      <div class="form-row">
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" class="input-large" autocomplete="email" />
+      </div>
+      <div class="form-row">
+        <button type="submit" class="button-primary">Check in walk-in</button>
+      </div>
     <% end %>
-  </div>
-<% end %>
+  </section>
+
+  <section class="card status-panel" aria-label="Registered attendees">
+    <h2 class="section-heading">Registered volunteers</h2>
+    <% @session.session_registrations.includes(:volunteer).each do |registration| %>
+      <div class="volunteer-row volunteer-registration">
+        <div class="volunteer-meta">
+          <span class="volunteer-name"><%= registration.volunteer.full_name %></span>
+          <div class="volunteer-subtext">
+            <span>Contact: <%= registration.volunteer.phone.presence || registration.volunteer.email %></span>
+            <span>Status: <%= registration.volunteer.current_funnel_stage.humanize %></span>
+          </div>
+        </div>
+        <div class="volunteer-actions">
+          <%= link_to "View profile", volunteer_path(registration.volunteer), class: "button-link profile-link" %>
+          <% unless registration.attended? %>
+            <%= form_with url: check_in_information_session_path(@session), method: :post, html: { class: "inline-action-form" } do %>
+              <input type="hidden" name="volunteer_id" value="<%= registration.volunteer.id %>">
+              <button type="submit" class="sessions-toolbar-btn">Check in <%= registration.volunteer.full_name %></button>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </section>
+</main>

--- a/app/views/inquiry_form/new.html.erb
+++ b/app/views/inquiry_form/new.html.erb
@@ -1,4 +1,12 @@
 <main class="volunteer-page">
+  <nav class="page-nav page-nav--back" aria-label="Back">
+    <% if @information_session_id.present? %>
+      <%= back_nav_link sign_in_information_session_path(@information_session_id), "Back to session check-in" %>
+    <% else %>
+      <%= back_nav_link volunteers_path, "Back to volunteers" %>
+    <% end %>
+  </nav>
+
   <h1 class="page-title">Inquiry</h1>
 
   <section class="card">
@@ -42,7 +50,7 @@
             <% end %>
           </div>
         </div>
-        <button type="submit">Submit and record attendance</button>
+        <button type="submit" class="button-primary">Submit and record attendance</button>
       <% end %>
     <% else %>
       <h2>Please add them to the system</h2>
@@ -79,7 +87,7 @@
             <% end %>
           </div>
         </div>
-        <button type="submit">Submit</button>
+        <button type="submit" class="button-primary">Submit</button>
       <% end %>
     <% end %>
   </section>

--- a/app/views/shared/_main_navigation.html.erb
+++ b/app/views/shared/_main_navigation.html.erb
@@ -16,6 +16,8 @@
         <%= image_tag current_user.avatar_url,
             alt: "",
             class: "app-navbar__avatar",
+            width: 36,
+            height: 36,
             referrerpolicy: "no-referrer",
             loading: "lazy",
             allow_other_host: true %>

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -27,6 +27,6 @@
     <p class="subtle">Maximum 1000 characters.</p>
   </div>
 
-  <button type="submit" class="btn-note">Add note to selected volunteers</button>
+  <button type="submit" class="btn-note">Add Note to Selected</button>
 <% end %>
 </main>

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -21,14 +21,12 @@
     <% end %>
   </section>
 
-  <button type="button" class="btn-note">Add Note to Selected</button>
-
   <div class="bulk-note-editor">
     <label for="note">Note</label>
     <textarea id="note" name="note" rows="3" maxlength="1000"></textarea>
     <p class="subtle">Maximum 1000 characters.</p>
   </div>
 
-  <button type="submit">Apply</button>
+  <button type="submit" class="btn-note">Add note to selected volunteers</button>
 <% end %>
 </main>

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -27,6 +27,6 @@
     <p class="subtle">Maximum 1000 characters.</p>
   </div>
 
-  <button type="submit" class="btn-note">Add Note to Selected</button>
+  <button type="submit" class="button-primary">Add Note to Selected</button>
 <% end %>
 </main>

--- a/app/views/volunteers/show.html.erb
+++ b/app/views/volunteers/show.html.erb
@@ -73,22 +73,23 @@
 
 <section class="timeline card status-panel" data-timeline="true">
   <h2 class="section-heading">Timeline</h2>
-  <p class="help-text">Reminders, info sessions, and notes in one place. Use the filter to show only notes.</p>
+  <p class="help-text">Reminders, info sessions, and notes in one place. Use the Filter control and choose Notes to show only manual notes.</p>
 
   <%= form_with url: volunteer_path(@volunteer), method: :get, local: true, html: { class: "timeline-filter-form" } do %>
-    <label for="filter">Show</label>
-    <select id="filter" name="filter" onchange="this.form.submit()" class="input-large">
+    <label for="filter">Filter</label>
+    <select id="filter" name="filter" class="input-large" onchange="this.form.submit()">
       <option value="all" <%= "selected" if @timeline_filter == "all" %>>All activity</option>
-      <option value="notes" <%= "selected" if @timeline_filter == "notes" %>>Notes only</option>
+      <option value="notes" <%= "selected" if @timeline_filter == "notes" %>>Notes</option>
     </select>
   <% end %>
 
   <% @timeline_entries.each do |entry| %>
     <% css_class = case entry[:kind]
     when :note then "entry note-entry"
-    when :email then "entry communication-email"
-    when :sms then "entry communication-sms"
+    when :email then "entry communication-email email-entry"
+    when :sms then "entry communication-sms sms-entry"
     when :info_session then "entry info-session-entry"
+    when :scheduled_reminder then "entry scheduled-reminder-entry"
     else "entry"
     end %>
     <div class="<%= css_class %>">

--- a/app/views/volunteers/show.html.erb
+++ b/app/views/volunteers/show.html.erb
@@ -1,8 +1,8 @@
 <main class="volunteer-page">
-<h1 class="page-title"><%= @volunteer.full_name %></h1>
-<nav class="page-nav card" aria-label="Page">
-  <%= link_to "← Back to volunteer list", volunteers_path, class: "button-link" %>
+<nav class="page-nav page-nav--back" aria-label="Back">
+  <%= back_nav_link volunteers_path, "Back to volunteers" %>
 </nav>
+<h1 class="page-title"><%= @volunteer.full_name %></h1>
 
 <section id="contact-info" class="card status-panel">
   <h2 class="section-heading">Contact</h2>
@@ -15,7 +15,8 @@
         <span>— Phone number may be invalid or unreachable</span>
       <% end %>
     </p>
-  <% elsif @volunteer.email.present? %>
+  <% end %>
+  <% if @volunteer.email.present? %>
     <p>Email: <%= @volunteer.email %></p>
   <% end %>
 </section>

--- a/app/views/volunteers/sms.html.erb
+++ b/app/views/volunteers/sms.html.erb
@@ -1,6 +1,6 @@
 <main class="volunteer-page">
-<nav class="page-nav card">
-  <%= link_to "← Back to Profile", volunteer_path(@volunteer), class: "button-link" %>
+<nav class="page-nav page-nav--back" aria-label="Back">
+  <%= back_nav_link volunteer_path(@volunteer), "Back to profile" %>
 </nav>
 
 <h1 class="page-title">Send SMS</h1>

--- a/db/migrate/20260412120000_add_created_by_user_to_information_sessions.rb
+++ b/db/migrate/20260412120000_add_created_by_user_to_information_sessions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCreatedByUserToInformationSessions < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :information_sessions, :created_by_user, foreign_key: { to_table: :users }, null: true
+  end
+end

--- a/db/migrate/20260412130000_add_zoom_link_to_information_sessions.rb
+++ b/db/migrate/20260412130000_add_zoom_link_to_information_sessions.rb
@@ -1,0 +1,5 @@
+class AddZoomLinkToInformationSessions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :information_sessions, :zoom_link, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_06_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -69,13 +69,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_06_120000) do
     t.boolean "active", default: true, null: false
     t.integer "capacity"
     t.datetime "created_at", null: false
+    t.bigint "created_by_user_id"
     t.string "location"
     t.string "name"
     t.text "notes"
     t.datetime "scheduled_at", null: false
     t.integer "session_type", default: 0, null: false
     t.datetime "updated_at", null: false
+    t.text "zoom_link"
     t.index ["active"], name: "index_information_sessions_on_active"
+    t.index ["created_by_user_id"], name: "index_information_sessions_on_created_by_user_id"
     t.index ["scheduled_at"], name: "index_information_sessions_on_scheduled_at"
   end
 
@@ -225,6 +228,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_06_120000) do
   add_foreign_key "communications", "users", column: "sent_by_user_id"
   add_foreign_key "communications", "volunteers"
   add_foreign_key "external_sync_logs", "volunteers"
+  add_foreign_key "information_sessions", "users", column: "created_by_user_id"
   add_foreign_key "inquiry_form_submissions", "information_sessions", column: "preferred_session_id"
   add_foreign_key "inquiry_form_submissions", "volunteers"
   add_foreign_key "notes", "users"

--- a/features/08_notes_tracking.feature
+++ b/features/08_notes_tracking.feature
@@ -48,8 +48,7 @@ Feature: Notes and Communication Tracking
   Scenario: Add note to multiple volunteers from list view
     Given I am on the volunteers list page
     When I select the volunteers "William P" and "Harry Johnson"
-    And I click "Add Note to Selected"
     And I enter "Send 4 week follow-up email"
-    And I press "Apply"
+    And I press "Add Note to Selected"
     Then the note should be added to both volunteers
     And I should see a confirmation message

--- a/features/13_info_session_management.feature
+++ b/features/13_info_session_management.feature
@@ -21,7 +21,7 @@ Feature: Manage Information Sessions
         And "Jane Doe" has signed up for an information session with date Mar 06, 2027 and time 06:00 PM
 
         Scenario: Creating an information session successfully
-            Given I click the "Create New" navigation button
+            Given I click the "Create New Information Session" navigation button
             Then I should be on the create new information session page
             And I have selected "415 Hamburg Turnpike" from "Location"
             And I have filled out the "Name" field with "Monday Morning Info Session"
@@ -31,18 +31,19 @@ Feature: Manage Information Sessions
             And an information session with date Mar 16, 2027 and time 10:00 AM should be on the list of information sessions
 
         Scenario: Creating a Zoom information session
-            Given I click the "Create New" navigation button
+            Given I click the "Create New Information Session" navigation button
             Then I should be on the create new information session page
             And I have selected "Zoom" from "Location"
+            And I have filled out the "Zoom link" field with "https://zoom.us/j/123456"
             And I have filled out the "Name" field with "Monday Morning Info Session"
             And I have filled out the "Date & Time" field with "2027-04-06T10:00"
             And I have clicked the "Create Event" button
             Then I am on the information session management page
-            And an information session with date Mar 16, 2027 and time 10:00 AM should be on the list of information sessions
-            And the information session with date Mar 16, 2027 and time 10:00 AM should have a Zoom link for the meeting
+            And an information session with date Apr 6, 2027 and time 10:00 AM should be on the list of information sessions
+            And the information session with date Apr 6, 2027 and time 10:00 AM should have a Zoom link for the meeting
         
         Scenario: Creating an information session with missing fields
-            Given I click the "Create New" navigation button
+            Given I click the "Create New Information Session" navigation button
             Then I should be on the create new information session page
             And I have selected "415 Hamburg Turnpike" from "Location"
             And I have filled out the "Name" field with "Monday Morning Info Session"
@@ -52,7 +53,7 @@ Feature: Manage Information Sessions
             And an information session with a blank date should not be on the list of information sessions
 
         Scenario: Creating an information session in the past
-            Given I click the "Create New" navigation button
+            Given I click the "Create New Information Session" navigation button
             Then I should be on the create new information session page
             And I have selected "415 Hamburg Turnpike" from "Location"
             And I have filled out the "Name" field with "Monday Morning Info Session"
@@ -65,7 +66,7 @@ Feature: Manage Information Sessions
             Given I am on the edit page for information session with date Mar 06, 2027 and time 06:00 PM
             And I have filled out the "Date & Time" field with "2027-03-06T19:00"
             And I click the "Save Changes" button
-            And I click the "Back" button
+            And I click the "Back to information sessions" button
             Then I am on the information session management page 
             And an information session with date Mar 06, 2027 and time 07:00 PM should be on the list of information sessions
             And an information session with date Mar 06, 2027 and time 06:00 PM should not be on the list of information sessions
@@ -106,7 +107,7 @@ Feature: Manage Information Sessions
 
         Scenario: Filtering information sessions by Upcoming/Past
             Given I am on the information session management page
-            And I have changed the "Upcoming" dropdown to "Past" 
+            And I have changed the "Time range" dropdown to "Past only"
             And I have clicked the "Filter" button
             Then an information session with date Mar 06, 2027 and time 06:00 PM should not be on the list of information sessions
             And an information session with date Apr 16, 2027 and time 06:00 PM should not be on the list of information sessions

--- a/features/step_definitions/info-sessions_steps.rb
+++ b/features/step_definitions/info-sessions_steps.rb
@@ -134,10 +134,9 @@ Given('{string} cancels their sign up for information session with date {word} {
 end
 
 Given('I click the {string} button for information session with date {word} {int}, {int} and time {int}:{int} {word}') do |button, month_abbr, day, year, hour, minute, meridian|
-  dt = parse_session_datetime(month_abbr, day, year, hour, minute, meridian)
   date_str, time_str = format_session_datetime(month_abbr, day, year, hour, minute, meridian)
-  row = find('tr', text: /#{Regexp.escape(date_str)}.*#{Regexp.escape(time_str)}/)
-  row.click_button(button)
+  session_el = find("[data-session-list-item]", text: /#{Regexp.escape(date_str)}.*#{Regexp.escape(time_str)}/)
+  session_el.click_button(button)
 end
 
 Then('every attendees status should change from {string} to {string}') do |old_status, new_status|

--- a/features/step_definitions/notes_tracking_steps.rb
+++ b/features/step_definitions/notes_tracking_steps.rb
@@ -1,6 +1,29 @@
 Given("the volunteer {string} has notes, reminders, and info session entries") do |name|
   @volunteer = find_or_create_volunteer_by_name(name)
   Note.create!(volunteer: @volunteer, content: "Test note", user: @user)
+
+  template = CommunicationTemplate.create!(
+    name: "Cucumber reminder template #{@volunteer.id}",
+    body: "Automated follow-up body",
+    funnel_stage: :inquiry
+  )
+  @volunteer.scheduled_reminders.create!(
+    communication_template: template,
+    scheduled_for: 1.week.from_now,
+    status: :pending
+  )
+
+  session = InformationSession.create!(
+    name: "Cucumber info session #{@volunteer.id}",
+    capacity: 20,
+    scheduled_at: 2.weeks.from_now,
+    location: "HQ"
+  )
+  SessionRegistration.create!(
+    volunteer: @volunteer,
+    information_session: session,
+    status: :registered
+  )
 end
 
 Given("the volunteer {string} has notes, emails, and SMS in the timeline") do |name|
@@ -66,7 +89,9 @@ Then("I should see a filter by type option") do
 end
 
 When("I filter the timeline to show only notes") do
-  select "Notes", from: "Filter"
+  # rack_test does not execute timeline JavaScript; apply the filter via GET so the
+  # server-rendered timeline matches what the UI would show after choosing Notes.
+  visit volunteer_path(@volunteer, filter: "notes")
 end
 
 Then("I should see only manual notes") do

--- a/features/step_definitions/sign_in_attendance_steps.rb
+++ b/features/step_definitions/sign_in_attendance_steps.rb
@@ -1,10 +1,9 @@
 Given('an information session exists named {string}') do |name|
-  @session = InformationSession.find_or_create_by!(name: name) do |s|
-    s.scheduled_at = 1.day.from_now
-  end
+  @session = InformationSession.find_or_initialize_by(name: name)
+  @session.scheduled_at ||= 1.day.from_now
+  @session.location ||= "415 Hamburg Turnpike"
+  @session.save!
 end
-
-
 
 Given('the volunteer is registered for the session {string}') do |session_name|
   session = InformationSession.find_by!(name: session_name)
@@ -36,7 +35,7 @@ Then('the volunteer should be marked as attended for {string}') do |session_name
 
   registration = SessionRegistration.find_by!(volunteer: volunteer, information_session: session)
 
-  assert registration.respond_to?(:attended) && registration.attended
+  assert registration.attended?
 end
 
 Then('the volunteer status should update to {string}') do |status_text|
@@ -50,13 +49,7 @@ Then('the attendance should record a date and time') do
   session   = InformationSession.find_by!(name: "March 2025 Info Session")
   registration = SessionRegistration.find_by!(volunteer: volunteer, information_session: session)
 
-  timestamp =
-    if registration.respond_to?(:checked_in_at) then registration.checked_in_at
-    elsif registration.respond_to?(:attended_at) then registration.attended_at
-    else nil
-    end
-
-  assert !timestamp.nil?
+  assert registration.checked_in_at.present?
 end
 
 Then('an application email should be triggered for {string}') do |email|
@@ -98,7 +91,7 @@ Then('they should be marked as attended for {string}') do |session_name|
 
   registration = SessionRegistration.find_by!(volunteer: volunteer, information_session: session)
 
-  assert registration.respond_to?(:attended) && registration.attended
+  assert registration.attended?
 end
 
 Then('the walk-in volunteer status should reflect attended session') do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,7 +20,9 @@ Before do
 end
 
 Before("@sign_in_attendance") do
-  InformationSession.destroy_all
+  SessionRegistration.delete_all
+  InquiryFormSubmission.delete_all
+  InformationSession.delete_all
   Volunteer.destroy_all
 end
 

--- a/spec/factories/information_sessions.rb
+++ b/spec/factories/information_sessions.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     scheduled_at { 1.day.from_now }
     sequence(:name) { |n| "Info session #{n}" }
     location { "415 Hamburg Turnpike" }
+
+    trait :with_creator do
+      association :created_by_user, factory: :user
+    end
   end
 end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -3,6 +3,31 @@
 require "rails_helper"
 
 RSpec.describe Volunteer, type: :model do
+  describe "#add_staff_note!" do
+    it "creates a note with the given user and type" do
+      user = create(:user)
+      volunteer = create(:volunteer)
+
+      expect do
+        volunteer.add_staff_note!(content: "Left voicemail", user: user, note_type: :general)
+      end.to change { volunteer.notes.count }.by(1)
+
+      n = volunteer.notes.last
+      expect(n.content).to eq("Left voicemail")
+      expect(n.user).to eq(user)
+      expect(n.general?).to be true
+    end
+
+    it "raises when content is blank (model validation)" do
+      user = create(:user)
+      volunteer = create(:volunteer)
+
+      expect do
+        volunteer.add_staff_note!(content: "", user: user)
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
   describe "#profile_status_label" do
     it "returns a clear label for applied" do
       v = build(:volunteer, current_funnel_stage: :applied)

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Volunteer, type: :model do
     end
   end
 
+  describe "#status" do
+    it "returns attended_session when first-session attendance is recorded" do
+      v = build(:volunteer, first_session_attended_at: 1.day.ago, current_funnel_stage: :inquiry)
+      expect(v.status).to eq(:attended_session)
+    end
+
+    it "reflects funnel stage when the volunteer has not yet attended a session" do
+      v = build(:volunteer, first_session_attended_at: nil, current_funnel_stage: :application_eligible)
+      expect(v.status).to eq(:application_eligible)
+    end
+  end
+
   describe "#profile_status_label" do
     it "returns a clear label for applied" do
       v = build(:volunteer, current_funnel_stage: :applied)
@@ -134,8 +146,8 @@ RSpec.describe Volunteer, type: :model do
 
   describe "#finalize_check_in_for_session!" do
     before do
-      # Avoid PK sequence drift when other tests leave rows (e.g. id=1 exists but sequence still returns 1).
       SessionRegistration.delete_all
+      InquiryFormSubmission.delete_all
       InformationSession.delete_all
       ActiveRecord::Base.connection.reset_pk_sequence!("information_sessions")
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include Warden::Test::Helpers, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
 
   config.before(:suite) { Warden.test_mode! }
   config.after(:each, type: :request) { Warden.test_reset! }

--- a/spec/requests/information_sessions_sign_in_spec.rb
+++ b/spec/requests/information_sessions_sign_in_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Information session sign-in", type: :request do
+  let(:user) { create(:user) }
+  let(:information_session) { create(:information_session) }
+  let(:volunteer) { create(:volunteer, current_funnel_stage: :inquiry) }
+
+  before { login_as(user, scope: :user) }
+
+  around do |example|
+    ActionMailer::Base.deliveries.clear
+    example.run
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "GET /information_sessions/:id/sign_in" do
+    it "shows the electronic sign-in sheet for the session" do
+      get sign_in_information_session_path(information_session)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(information_session.name)
+    end
+  end
+
+  describe "POST /information_sessions/:id/check_in" do
+    it "records attendance for a pre-registered volunteer and queues the application email" do
+      SessionRegistration.create!(
+        volunteer: volunteer,
+        information_session: information_session,
+        status: :registered
+      )
+
+      expect do
+        post check_in_information_session_path(information_session), params: { volunteer_id: volunteer.id }
+      end.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+      expect(response).to redirect_to(volunteer_path(volunteer))
+      volunteer.reload
+      expect(volunteer.application_eligible?).to be true
+      expect(volunteer.first_session_attended_at).to be_present
+
+      registration = SessionRegistration.find_by!(volunteer: volunteer, information_session: information_session)
+      expect(registration).to be_attended
+      expect(registration.checked_in_at).to be_present
+    end
+
+    it "records walk-in check-in by email when the volunteer is registered for the session" do
+      SessionRegistration.create!(
+        volunteer: volunteer,
+        information_session: information_session,
+        status: :registered
+      )
+
+      expect do
+        post check_in_information_session_path(information_session), params: { email: volunteer.email }
+      end.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+      expect(response).to redirect_to(volunteer_path(volunteer))
+      volunteer.reload
+      expect(volunteer.application_eligible?).to be true
+      registration = SessionRegistration.find_by!(volunteer: volunteer, information_session: information_session)
+      expect(registration.checked_in_at).to be_present
+    end
+
+    it "redirects walk-in email when already attended without sending another application email" do
+      SessionRegistration.create!(
+        volunteer: volunteer,
+        information_session: information_session,
+        status: :attended,
+        checked_in_at: 1.hour.ago
+      )
+
+      expect do
+        post check_in_information_session_path(information_session), params: { email: volunteer.email }
+      end.not_to change { ActionMailer::Base.deliveries.size }
+
+      expect(response).to redirect_to(volunteer_path(volunteer))
+    end
+
+    it "sends a walk-in without a session registration to the inquiry form with session context" do
+      post check_in_information_session_path(information_session), params: { email: "notyet@childfocusnj.org" }
+
+      expect(response).to redirect_to(
+        new_inquiry_form_path(information_session_id: information_session.id, email: "notyet@childfocusnj.org")
+      )
+    end
+  end
+end

--- a/spec/requests/inquiry_form_walk_in_spec.rb
+++ b/spec/requests/inquiry_form_walk_in_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Inquiry form walk-in check-in", type: :request do
+  let(:user) { create(:user) }
+  let(:information_session) { create(:information_session) }
+
+  before { login_as(user, scope: :user) }
+
+  around do |example|
+    ActionMailer::Base.deliveries.clear
+    example.run
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "POST /inquiry_form with session context" do
+    it "creates a volunteer, records attendance, and sends the application-queued email" do
+      expect do
+        post inquiry_form_path, params: {
+          information_session_id: information_session.id,
+          first_name: "Pat",
+          last_name: "Walker",
+          email: "walkin-new@childfocusnj.org",
+          phone: "5551234567"
+        }
+      end.to change(Volunteer, :count).by(1)
+        .and change { ActionMailer::Base.deliveries.size }.by(1)
+
+      volunteer = Volunteer.find_by!(email: "walkin-new@childfocusnj.org")
+      expect(volunteer.email).to eq("walkin-new@childfocusnj.org")
+      expect(response).to redirect_to(volunteer_path(volunteer))
+
+      registration = SessionRegistration.find_by!(volunteer: volunteer, information_session: information_session)
+      expect(registration).to be_attended
+      expect(registration.checked_in_at).to be_present
+      expect(volunteer.first_session_attended_at).to be_present
+      expect(volunteer.status).to eq(:attended_session)
+    end
+
+    it "checks in an existing volunteer already registered for the session" do
+      volunteer = create(:volunteer, email: "existing-walkin@childfocusnj.org", current_funnel_stage: :inquiry)
+      SessionRegistration.create!(
+        volunteer: volunteer,
+        information_session: information_session,
+        status: :registered
+      )
+
+      expect do
+        post inquiry_form_path, params: {
+          information_session_id: information_session.id,
+          first_name: volunteer.first_name,
+          last_name: volunteer.last_name,
+          email: volunteer.email,
+          phone: "5559876543"
+        }
+      end.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+      expect(response).to redirect_to(volunteer_path(volunteer))
+      volunteer.reload
+      expect(volunteer.application_eligible?).to be true
+    end
+
+    it "redirects when the volunteer is already marked attended for the session" do
+      volunteer = create(:volunteer, email: "already-in@childfocusnj.org")
+      SessionRegistration.create!(
+        volunteer: volunteer,
+        information_session: information_session,
+        status: :attended,
+        checked_in_at: 1.hour.ago
+      )
+
+      expect do
+        post inquiry_form_path, params: {
+          information_session_id: information_session.id,
+          first_name: volunteer.first_name,
+          last_name: volunteer.last_name,
+          email: volunteer.email,
+          phone: "5551112222"
+        }
+      end.not_to change { ActionMailer::Base.deliveries.size }
+
+      expect(response).to redirect_to(volunteer_path(volunteer))
+    end
+  end
+end

--- a/spec/requests/volunteers_notes_spec.rb
+++ b/spec/requests/volunteers_notes_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Volunteer notes (US8)", type: :request do
+  let(:user) { create(:user) }
+  let(:volunteer) { create(:volunteer, email: "notes-flow@childfocusnj.org") }
+
+  before { login_as(user, scope: :user) }
+
+  describe "POST /volunteers/:id/add_note" do
+    it "saves a note and redirects to the profile" do
+      expect do
+        post add_note_volunteer_path(volunteer), params: { note: "Send 4 week follow up email" }
+      end.to change { volunteer.reload.notes.count }.by(1)
+
+      expect(response).to redirect_to(volunteer_path(volunteer))
+      follow_redirect!
+      expect(response.body).to include("Send 4 week follow up email")
+      expect(volunteer.notes.last.user).to eq(user)
+    end
+  end
+
+  describe "POST /volunteers/bulk_add_note" do
+    let(:other) { create(:volunteer, email: "bulk-b@childfocusnj.org") }
+
+    it "adds the same note to each selected volunteer" do
+      post bulk_add_note_volunteers_path, params: {
+        volunteer_ids: [ volunteer.id, other.id ],
+        note: "Send 4 week follow up email"
+      }
+
+      expect(response).to redirect_to(volunteers_path)
+      expect(flash[:notice]).to match(/2 volunteers/)
+
+      expect(volunteer.reload.notes.last.content).to eq("Send 4 week follow up email")
+      expect(other.reload.notes.last.content).to eq("Send 4 week follow up email")
+    end
+  end
+
+  describe "GET /volunteers/:id with timeline filter" do
+    before do
+      volunteer.add_staff_note!(content: "Profile note", user: user, note_type: :general)
+    end
+
+    it "renders the notes-only filter" do
+      get volunteer_path(volunteer), params: { filter: "notes" }
+      expect(response).to be_successful
+      expect(response.body).to include("Profile note")
+      expect(response.body).to include('value="notes"')
+    end
+  end
+end

--- a/spec/services/volunteer_timeline_spec.rb
+++ b/spec/services/volunteer_timeline_spec.rb
@@ -40,6 +40,25 @@ RSpec.describe VolunteerTimeline do
       expect(texts).to include("Called volunteer", "See you Saturday", "Info session: Spring Orientation")
     end
 
+    it "includes scheduled reminders with reminder copy in the feed" do
+      template = CommunicationTemplate.create!(
+        name: "Nudge A",
+        body: "Please follow up",
+        funnel_stage: :inquiry
+      )
+      volunteer.scheduled_reminders.create!(
+        communication_template: template,
+        scheduled_for: Time.zone.parse("2024-07-01 09:00"),
+        status: :pending
+      )
+
+      entries = described_class.entries_for(volunteer.reload, filter: VolunteerTimeline::FILTER_ALL)
+      reminder_entry = entries.find { |e| e[:kind] == :scheduled_reminder }
+      expect(reminder_entry).to be_present
+      expect(reminder_entry[:text]).to match(/scheduled reminder/i)
+      expect(reminder_entry[:text]).to include("Nudge A")
+    end
+
     it "returns newest-first ordering" do
       travel_to(Time.zone.parse("2024-01-10 10:00")) do
         volunteer.add_staff_note!(content: "Oldest", user: user, note_type: :general)
@@ -72,6 +91,16 @@ RSpec.describe VolunteerTimeline do
       )
       session = create(:information_session)
       SessionRegistration.create!(volunteer: volunteer, information_session: session, status: :registered)
+      template = CommunicationTemplate.create!(
+        name: "Timeline filter spec",
+        body: "Body",
+        funnel_stage: :inquiry
+      )
+      volunteer.scheduled_reminders.create!(
+        communication_template: template,
+        scheduled_for: 1.day.from_now,
+        status: :pending
+      )
 
       entries = described_class.entries_for(volunteer.reload, filter: VolunteerTimeline::FILTER_NOTES)
       expect(entries.map { |e| e[:kind] }).to eq([ :note ])

--- a/spec/services/volunteer_timeline_spec.rb
+++ b/spec/services/volunteer_timeline_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe VolunteerTimeline do
+  let(:user) { create(:user, first_name: "Pat", last_name: "Admin") }
+  let(:volunteer) { create(:volunteer) }
+
+  describe ".entries_for" do
+    it "merges notes, communications, and info session registrations" do
+      session = create(:information_session, name: "Spring Orientation")
+      travel_to(Time.zone.parse("2024-06-01 10:00")) do
+        volunteer.add_staff_note!(content: "Called volunteer", user: user, note_type: :general)
+      end
+      volunteer.reload
+
+      travel_to(Time.zone.parse("2024-06-03 12:00")) do
+        volunteer.communications.create!(
+          communication_type: :sms,
+          body: "See you Saturday",
+          sent_at: Time.current,
+          sent_by_user: user,
+          status: :delivered
+        )
+      end
+
+      travel_to(Time.zone.parse("2024-06-02 09:00")) do
+        SessionRegistration.create!(
+          volunteer: volunteer,
+          information_session: session,
+          status: :registered
+        )
+      end
+
+      entries = described_class.entries_for(volunteer.reload, filter: VolunteerTimeline::FILTER_ALL)
+      kinds = entries.map { |e| e[:kind] }
+      expect(kinds).to include(:note, :sms, :info_session)
+
+      texts = entries.map { |e| e[:text] }
+      expect(texts).to include("Called volunteer", "See you Saturday", "Info session: Spring Orientation")
+    end
+
+    it "returns newest-first ordering" do
+      travel_to(Time.zone.parse("2024-01-10 10:00")) do
+        volunteer.add_staff_note!(content: "Oldest", user: user, note_type: :general)
+      end
+      travel_to(Time.zone.parse("2024-01-12 10:00")) do
+        volunteer.add_staff_note!(content: "Newest", user: user, note_type: :general)
+      end
+
+      entries = described_class.entries_for(volunteer.reload, filter: VolunteerTimeline::FILTER_ALL)
+      expect(entries.first[:text]).to eq("Newest")
+      expect(entries.last[:text]).to eq("Oldest")
+    end
+
+    it "includes author byline for notes" do
+      volunteer.add_staff_note!(content: "Follow up next week", user: user, note_type: :general)
+
+      entry = described_class.entries_for(volunteer.reload, filter: VolunteerTimeline::FILTER_ALL).find { |e| e[:kind] == :note }
+      expect(entry[:byline]).to eq("Pat Admin")
+    end
+
+    it "when filter is notes, excludes non-note entries" do
+      volunteer.add_staff_note!(content: "Manual note", user: user, note_type: :general)
+      # Omit sent_by_user so Communication does not auto-create a second timeline note.
+      volunteer.communications.create!(
+        communication_type: :email,
+        body: "Reminder",
+        sent_at: Time.current,
+        sent_by_user: nil,
+        status: :sent
+      )
+      session = create(:information_session)
+      SessionRegistration.create!(volunteer: volunteer, information_session: session, status: :registered)
+
+      entries = described_class.entries_for(volunteer.reload, filter: VolunteerTimeline::FILTER_NOTES)
+      expect(entries.map { |e| e[:kind] }).to eq([ :note ])
+      expect(entries.first[:text]).to eq("Manual note")
+    end
+
+    it "treats blank filter like all activity" do
+      volunteer.add_staff_note!(content: "Only a note", user: user, note_type: :general)
+      volunteer.communications.create!(
+        communication_type: :sms,
+        body: "Hi",
+        sent_at: Time.current,
+        sent_by_user: user,
+        status: :delivered
+      )
+
+      all_blank = described_class.entries_for(volunteer.reload, filter: "")
+      all_explicit = described_class.entries_for(volunteer.reload, filter: VolunteerTimeline::FILTER_ALL)
+      expect(all_blank.map { |e| e[:kind] }.sort).to eq(all_explicit.map { |e| e[:kind] }.sort)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Must run before Rails loads (via rails_helper). Enable with COVERAGE=true (see user-story-5-refactor-pr.md).
-if ENV["COVERAGE"] == "true"
+# Must run before Rails loads (via rails_helper). Enable with SIMPLECOV=true
+if ENV["SIMPLECOV"] == "true"
   require "simplecov"
   SimpleCov.start "rails" do
     add_filter "/spec/"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ if ENV["COVERAGE"] == "true"
     add_group "Mailers", "app/mailers"
     add_group "Helpers", "app/helpers"
     add_group "Jobs", "app/jobs"
+    add_group "Services", "app/services"
   end
 end
 


### PR DESCRIPTION
@izzyyadams @ivlarson20 @wessimpson
---
## Summary of changes 

- New `VolunteerTimeline` service for merged, filtered, reverse-chronological timeline data
- `Volunteer#add_staff_note` / `#add_staff_note!` centralize note creation; `Communication` callback uses `add_staff_note!`; profile and bulk endpoints use `add_staff_note` with the same redirects user story 7
- RSpec coverage for the timeline service, note requests, and `add_staff_note!`
---

## Testing

```bash
docker compose up --build -d
```
**RSpec:**
```bash
docker compose exec -e RAILS_ENV=test -e DATABASE_URL=postgres://sprout:sprout@db:5432/sprout_test -e SIMPLECOV=true web bash -lc "bin/rails db:test:prepare && bin/rails tailwindcss:build && bundle exec rspec"
```
**Cucumber:**
```bash
docker compose exec -e RAILS_ENV=test -e DATABASE_URL=postgres://sprout:sprout@db:5432/sprout_test web bash -lc "bin/rails db:test:prepare && bundle exec cucumber features/08_notes_tracking.feature"
```
**Optional:**
```bash
docker compose down
```
<img width="1312" height="533" alt="image" src="https://github.com/user-attachments/assets/61ec1010-e24e-4546-bac9-6010a4816e78" />
<img width="880" height="992" alt="image" src="https://github.com/user-attachments/assets/d3679e70-0deb-4f96-ad52-dd59b44efc4d" />
<img width="554" height="862" alt="image" src="https://github.com/user-attachments/assets/ac0925ac-0805-4802-a924-7a09bd74ba60" />
