### PR TITLE
Implement UI for user stories 1-4 including email templates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,7 @@ GEM
     ffi (1.17.3-arm-linux-gnu)
     ffi (1.17.3-arm-linux-musl)
     ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86_64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
     ffi (1.17.3-x86_64-linux-musl)
     fugit (1.12.1)
@@ -285,6 +286,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.19.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-musl)
@@ -319,6 +322,7 @@ GEM
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
     pp (0.6.3)
@@ -497,12 +501,14 @@ GEM
     tailwindcss-ruby (4.2.2-aarch64-linux-gnu)
     tailwindcss-ruby (4.2.2-aarch64-linux-musl)
     tailwindcss-ruby (4.2.2-arm64-darwin)
+    tailwindcss-ruby (4.2.2-x86_64-darwin)
     tailwindcss-ruby (4.2.2-x86_64-linux-gnu)
     tailwindcss-ruby (4.2.2-x86_64-linux-musl)
     thor (1.5.0)
     thruster (0.1.17)
     thruster (0.1.17-aarch64-linux)
     thruster (0.1.17-arm64-darwin)
+    thruster (0.1.17-x86_64-darwin)
     thruster (0.1.17-x86_64-linux)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -544,6 +550,7 @@ PLATFORMS
   arm-linux-musl
   arm64-darwin-23
   arm64-darwin-25
+  x86_64-darwin-24
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl
@@ -653,6 +660,7 @@ CHECKSUMS
   ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
   ffi (1.17.3-arm-linux-musl) sha256=0d7626bb96265f9af78afa33e267d71cfef9d9a8eb8f5525344f8da6c7d76053
   ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
+  ffi (1.17.3-x86_64-darwin) sha256=1f211811eb5cfaa25998322cdd92ab104bfbd26d1c4c08471599c511f2c00bb5
   ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
   ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
@@ -698,6 +706,7 @@ CHECKSUMS
   nokogiri (1.19.2-arm-linux-gnu) sha256=b7fa1139016f3dc850bda1260988f0d749934a939d04ef2da13bec060d7d5081
   nokogiri (1.19.2-arm-linux-musl) sha256=61114d44f6742ff72194a1b3020967201e2eb982814778d130f6471c11f9828c
   nokogiri (1.19.2-arm64-darwin) sha256=58d8ea2e31a967b843b70487a44c14c8ba1866daa1b9da9be9dbdf1b43dee205
+  nokogiri (1.19.2-x86_64-darwin) sha256=7d9af11fda72dfaa2961d8c4d5380ca0b51bc389dc5f8d4b859b9644f195e7a4
   nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
   nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
   oauth2 (2.0.18) sha256=bacf11e470dfb963f17348666d0a75c7b29ca65bc48fd47be9057cf91a403287
@@ -711,6 +720,7 @@ CHECKSUMS
   pg (1.6.3-aarch64-linux) sha256=0698ad563e02383c27510b76bf7d4cd2de19cd1d16a5013f375dd473e4be72ea
   pg (1.6.3-aarch64-linux-musl) sha256=06a75f4ea04b05140146f2a10550b8e0d9f006a79cdaf8b5b130cde40e3ecc2c
   pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
+  pg (1.6.3-x86_64-darwin) sha256=ee2e04a17c0627225054ffeb43e31a95be9d7e93abda2737ea3ce4a62f2729d6
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
@@ -769,12 +779,14 @@ CHECKSUMS
   tailwindcss-ruby (4.2.2-aarch64-linux-gnu) sha256=8656621046bb54c9c368cd1d2f03f7bfaf6046a4fe7060c574b9958043f1deeb
   tailwindcss-ruby (4.2.2-aarch64-linux-musl) sha256=3dbaa653a5e9cddbb6bc73598a566d7172a91724463000cd594624dfe5b0eaec
   tailwindcss-ruby (4.2.2-arm64-darwin) sha256=2d66feba0c1ffca5b79246bd881bfb9a6b2298d57c4bc83ee3a8c3233df79d41
+  tailwindcss-ruby (4.2.2-x86_64-darwin) sha256=819b4c512763b52c7d47a60c4089e4b357ff8baad1e619984614f8d14d90dc46
   tailwindcss-ruby (4.2.2-x86_64-linux-gnu) sha256=7f5e7cdd697ff25600d684cedb4df4a56736633c231ee03c7148992c62fd228f
   tailwindcss-ruby (4.2.2-x86_64-linux-musl) sha256=676b802dafc677983d471f3acf2dddbddea4e978ea0300bfa21ebd6ab167d6a8
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   thruster (0.1.17) sha256=6f3f1de43e22f0162d81cbc363f45ee42a1b8460213856c1a899cbf0d3297235
   thruster (0.1.17-aarch64-linux) sha256=1b3a34b2814185c2aeaf835b5ecff5348cdcf8e77809f7a092d46e4b962a16ba
   thruster (0.1.17-arm64-darwin) sha256=75da66fc4a0f012f9a317f6362f786a3fa953879a3fa6bed8deeaebf1c1d66ec
+  thruster (0.1.17-x86_64-darwin) sha256=b49e4c52563d1476d3aa1e12f7f57febb4510ac163f6abeac7c7c0de8a54437f
   thruster (0.1.17-x86_64-linux) sha256=77b8f335075bd4ece7631dc84a19a710a1e6e7102cbce147b165b45851bdfcd3
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f

--- a/app/views/admin/communication_templates/_form.html.erb
+++ b/app/views/admin/communication_templates/_form.html.erb
@@ -1,0 +1,66 @@
+<!-- app/views/admin/communication_templates/_form.html.erb -->
+<%= form_with model: [:admin, template], class: "space-y-4" do |f| %>
+  <% if template.errors.any? %>
+    <section class="card border-red-300 bg-red-50">
+      <h2 class="section-heading">Please fix the following</h2>
+      <ul class="list-disc pl-5 text-sm text-red-800">
+        <% template.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </section>
+  <% end %>
+
+  <section class="card">
+    <h2 class="section-heading">Template details</h2>
+    <p class="help-text">
+      Use <code>{{first_name}}</code> anywhere in the subject or body to personalize the message.
+    </p>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <div class="space-y-1">
+        <%= f.label :name, class: "font-semibold text-gray-800" %>
+        <%= f.text_field :name, class: "input-large w-full max-w-none" %>
+      </div>
+
+      <div class="space-y-1">
+        <%= f.label :subject, class: "font-semibold text-gray-800" %>
+        <%= f.text_field :subject, class: "input-large w-full max-w-none" %>
+      </div>
+
+      <div class="space-y-1">
+        <%= f.label :funnel_stage, "Funnel stage", class: "font-semibold text-gray-800" %>
+        <%= f.select :funnel_stage,
+                     CommunicationTemplate.funnel_stages.keys.map { |stage| [stage.humanize, stage] },
+                     {},
+                     class: "input-large w-full max-w-none" %>
+      </div>
+
+      <div class="space-y-1">
+        <%= f.label :template_type, "Template type", class: "font-semibold text-gray-800" %>
+        <%= f.select :template_type,
+                     CommunicationTemplate.template_types.keys.map { |type| [type.upcase, type] },
+                     {},
+                     class: "input-large w-full max-w-none" %>
+      </div>
+
+      <div class="space-y-1 md:col-span-2">
+        <%= f.label :trigger_type, "Trigger type", class: "font-semibold text-gray-800" %>
+        <%= f.select :trigger_type,
+                     CommunicationTemplate.trigger_types.keys.map { |trigger| [trigger.humanize, trigger] },
+                     {},
+                     class: "input-large w-full max-w-none md:max-w-md" %>
+      </div>
+
+      <div class="space-y-1 md:col-span-2">
+        <%= f.label :body, class: "font-semibold text-gray-800" %>
+        <%= f.text_area :body, rows: 10, class: "w-full max-w-none border border-gray-400 rounded-md p-3 text-base" %>
+      </div>
+    </div>
+
+    <div class="mt-4 flex flex-wrap gap-2">
+      <%= f.submit "Save Template", class: "button-primary" %>
+      <%= link_to "Back to Templates", admin_communication_templates_path, class: "button-link" %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/admin/communication_templates/_form.html.erb
+++ b/app/views/admin/communication_templates/_form.html.erb
@@ -59,7 +59,7 @@
     </div>
 
     <div class="mt-4 flex flex-wrap gap-2">
-      <%= f.submit "Save Template", class: "button-primary" %>
+      <%= f.submit "Create", class: "button-primary" %>
       <%= link_to "Back to Templates", admin_communication_templates_path, class: "button-link" %>
     </div>
   </section>

--- a/app/views/admin/communication_templates/index.html.erb
+++ b/app/views/admin/communication_templates/index.html.erb
@@ -1,9 +1,54 @@
-<h1>Email Templates</h1>
-<%= link_to "New Template", new_admin_communication_template_path %>
-<table>
-  <% @templates.each do |template| %>
-    <tr class="template-row">
-      <td><%= link_to template.name, admin_communication_template_path(template), class: "template-name-link" %></td>
-    </tr>
+<!-- app/views/admin/communication_templates/index.html.erb -->
+<div class="volunteer-page">
+  <h1 class="page-title">Email Templates</h1>
+  <p class="help-text">
+    Manage reusable communication templates for inquiry follow-up, application reminders,
+    and other volunteer outreach.
+  </p>
+
+  <div class="mb-4">
+    <%= link_to "New Template", new_admin_communication_template_path, class: "button-primary" %>
+  </div>
+
+  <% if @templates.any? %>
+    <div class="grid gap-4">
+      <% @templates.each do |template| %>
+        <section class="card">
+          <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div class="space-y-2">
+              <h2 class="section-heading mb-0"><%= template.name %></h2>
+
+              <div class="text-sm text-gray-700 flex flex-wrap gap-2">
+                <span class="inline-flex items-center rounded-full border border-gray-300 px-3 py-1">
+                  <strong class="mr-1">Stage:</strong> <%= template.funnel_stage.humanize %>
+                </span>
+                <span class="inline-flex items-center rounded-full border border-gray-300 px-3 py-1">
+                  <strong class="mr-1">Type:</strong> <%= template.template_type.upcase %>
+                </span>
+                <span class="inline-flex items-center rounded-full border border-gray-300 px-3 py-1">
+                  <strong class="mr-1">Trigger:</strong> <%= template.trigger_type.humanize %>
+                </span>
+              </div>
+
+              <p class="subtle">
+                <strong>Subject:</strong> <%= template.subject.presence || "No subject" %>
+              </p>
+            </div>
+
+            <div class="action-toolbar">
+              <%= link_to "View", admin_communication_template_path(template), class: "button-link" %>
+              <%= link_to "Preview", preview_admin_communication_template_path(template), class: "button-link" %>
+            </div>
+          </div>
+        </section>
+      <% end %>
+    </div>
+  <% else %>
+    <section class="card">
+      <h2 class="section-heading">No templates yet</h2>
+      <p class="help-text mb-0">
+        Start by creating your first email template.
+      </p>
+    </section>
   <% end %>
-</table>
+</div>

--- a/app/views/admin/communication_templates/index.html.erb
+++ b/app/views/admin/communication_templates/index.html.erb
@@ -16,8 +16,11 @@
         <section class="card">
           <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
             <div class="space-y-2">
-              <h2 class="section-heading mb-0"><%= template.name %></h2>
-
+              <h2 class="section-heading mb-0">
+                <%= link_to template.name,
+                            admin_communication_template_path(template),
+                            class: "template-name-link" %>
+              </h2>
               <div class="text-sm text-gray-700 flex flex-wrap gap-2">
                 <span class="inline-flex items-center rounded-full border border-gray-300 px-3 py-1">
                   <strong class="mr-1">Stage:</strong> <%= template.funnel_stage.humanize %>

--- a/app/views/admin/communication_templates/new.html.erb
+++ b/app/views/admin/communication_templates/new.html.erb
@@ -1,10 +1,16 @@
-<h1>New Email Template</h1>
-<%= form_with model: [:admin, @template] do |f| %>
-  <div><%= f.label :name %><%= f.text_field :name %></div>
-  <div><%= f.label :subject %><%= f.text_field :subject %></div>
-  <div><%= f.label :body %><%= f.text_area :body %></div>
-  <div><%= f.label :funnel_stage %><%= f.select :funnel_stage, CommunicationTemplate.funnel_stages.keys %></div>
-  <div><%= f.label :template_type %><%= f.select :template_type, CommunicationTemplate.template_types.keys %></div>
-  <div><%= f.label :trigger_type %><%= f.select :trigger_type, CommunicationTemplate.trigger_types.keys %></div>
-  <%= f.submit "Create" %>
-<% end %>
+<!-- app/views/admin/communication_templates/new.html.erb -->
+<div class="volunteer-page">
+  <div class="page-nav page-nav--back">
+    <%= link_to admin_communication_templates_path, class: "nav-back" do %>
+      <span class="nav-back__chevron" aria-hidden="true">‹</span>
+      <span>Back to Email Templates</span>
+    <% end %>
+  </div>
+
+  <h1 class="page-title">New Email Template</h1>
+  <p class="help-text">
+    Create a reusable message for volunteers at a specific stage of the funnel.
+  </p>
+
+  <%= render "form", template: @template %>
+</div>

--- a/app/views/admin/communication_templates/preview.html.erb
+++ b/app/views/admin/communication_templates/preview.html.erb
@@ -17,7 +17,7 @@
 
     <%= form_with url: preview_admin_communication_template_path(@template), method: :post, class: "space-y-4" do %>
       <div class="space-y-1 max-w-md">
-        <%= label_tag :first_name, "Volunteer first name", class: "font-semibold text-gray-800" %>
+        <%= label_tag :first_name, "First name", class: "font-semibold text-gray-800" %>
         <%= text_field_tag :first_name, params[:first_name], class: "input-large w-full max-w-none" %>
       </div>
 

--- a/app/views/admin/communication_templates/preview.html.erb
+++ b/app/views/admin/communication_templates/preview.html.erb
@@ -1,9 +1,46 @@
-<h1>Preview: <%= @template.name %></h1>
-<%= form_with url: preview_admin_communication_template_path(@template), method: :post do |f| %>
-  <div><%= f.label :first_name, "First name" %><%= f.text_field :first_name %></div>
-  <%= f.submit "Preview" %>
-<% end %>
-<% if @preview_subject %>
-  <div><%= @preview_subject %></div>
-  <div><%= @preview_body %></div>
-<% end %>
+<!-- app/views/admin/communication_templates/preview.html.erb -->
+<div class="volunteer-page">
+  <div class="page-nav page-nav--back">
+    <%= link_to admin_communication_templates_path, class: "nav-back" do %>
+      <span class="nav-back__chevron" aria-hidden="true">‹</span>
+      <span>Back to Email Templates</span>
+    <% end %>
+  </div>
+
+  <h1 class="page-title">Preview: <%= @template.name %></h1>
+  <p class="help-text">
+    Enter a first name to preview how personalization appears in the subject and body.
+  </p>
+
+  <section class="card">
+    <h2 class="section-heading">Preview settings</h2>
+
+    <%= form_with url: preview_admin_communication_template_path(@template), method: :post, class: "space-y-4" do %>
+      <div class="space-y-1 max-w-md">
+        <%= label_tag :first_name, "Volunteer first name", class: "font-semibold text-gray-800" %>
+        <%= text_field_tag :first_name, params[:first_name], class: "input-large w-full max-w-none" %>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        <%= submit_tag "Generate Preview", class: "button-primary" %>
+        <%= link_to "View Template", admin_communication_template_path(@template), class: "button-link" %>
+      </div>
+    <% end %>
+  </section>
+
+  <% if @preview_subject.present? || @preview_body.present? %>
+    <section class="card">
+      <h2 class="section-heading">Preview output</h2>
+
+      <div class="mb-4">
+        <p class="font-semibold text-gray-800">Subject</p>
+        <p class="text-base text-gray-900"><%= @preview_subject %></p>
+      </div>
+
+      <div>
+        <p class="font-semibold text-gray-800">Body</p>
+        <div class="whitespace-pre-wrap text-base text-gray-900"><%= @preview_body %></div>
+      </div>
+    </section>
+  <% end %>
+</div>

--- a/app/views/admin/communication_templates/show.html.erb
+++ b/app/views/admin/communication_templates/show.html.erb
@@ -1,4 +1,47 @@
-<h1><%= @template.name %></h1>
-<p><%= @template.subject %></p>
-<p><%= @template.body %></p>
-<%= link_to "Preview", preview_admin_communication_template_path(@template) %>
+<!-- app/views/admin/communication_templates/show.html.erb -->
+<div class="volunteer-page">
+  <div class="page-nav page-nav--back">
+    <%= link_to admin_communication_templates_path, class: "nav-back" do %>
+      <span class="nav-back__chevron" aria-hidden="true">‹</span>
+      <span>Back to Email Templates</span>
+    <% end %>
+  </div>
+
+  <h1 class="page-title"><%= @template.name %></h1>
+
+  <section class="card">
+    <h2 class="section-heading">Template details</h2>
+
+    <div class="grid gap-3 md:grid-cols-3 text-sm text-gray-800">
+      <div>
+        <p class="font-semibold">Funnel stage</p>
+        <p><%= @template.funnel_stage.humanize %></p>
+      </div>
+
+      <div>
+        <p class="font-semibold">Template type</p>
+        <p><%= @template.template_type.upcase %></p>
+      </div>
+
+      <div>
+        <p class="font-semibold">Trigger type</p>
+        <p><%= @template.trigger_type.humanize %></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2 class="section-heading">Subject</h2>
+    <p class="text-base text-gray-900"><%= @template.subject.presence || "No subject" %></p>
+  </section>
+
+  <section class="card">
+    <h2 class="section-heading">Body</h2>
+    <div class="whitespace-pre-wrap text-base text-gray-900"><%= @template.body %></div>
+  </section>
+
+  <div class="action-toolbar">
+    <%= link_to "Preview Template", preview_admin_communication_template_path(@template), class: "button-primary" %>
+    <%= link_to "Back to Templates", admin_communication_templates_path, class: "button-link" %>
+  </div>
+</div>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -1,31 +1,30 @@
-<main class="volunteer-page max-w-3xl">
+<!-- app/views/admin/settings/index.html.erb -->
+<div class="volunteer-page">
   <h1 class="page-title">Admin settings</h1>
 
-  <section id="application-reminders" class="card status-panel">
+  <section id="application-reminders" class="card">
     <h2 class="section-heading">Application reminders</h2>
-    <p class="help-text">Automated nudges for volunteers who received application materials but have not submitted yet. Reminder frequency is configurable (meeting notes).</p>
+    <p class="help-text">
+      Automated nudges for volunteers who received application materials but have not
+      submitted yet. Reminder frequency is configurable.
+    </p>
 
-    <%= form_with url: admin_settings_path, method: :patch, local: true, html: { class: "admin-settings-form", id: "application-reminders-form" } do %>
+    <%= form_with url: admin_settings_path, method: :patch, local: true,
+                  html: { class: "admin-settings-form" } do %>
       <div class="form-row">
         <%= label_tag :application_reminder_interval_weeks, "Reminder interval" %>
-        <p class="subtle mb-2">How often to send reminder emails (frequency).</p>
         <%= select_tag :application_reminder_interval_weeks,
-            options_for_select(
-              [
-                [ "Every week", 1 ],
-                [ "Every 2 weeks", 2 ],
-                [ "Every 4 weeks", 4 ],
-                [ "Every 8 weeks", 8 ],
-                [ "Every 12 weeks", 12 ]
-              ],
-              @reminder_interval_weeks
-            ),
-            id: "reminder-interval",
-            class: "input-large" %>
+                       options_for_select(
+                         [["Every week", 1], ["Every 2 weeks", 2], ["Every 4 weeks", 4], ["Every 8 weeks", 8], ["Every 12 weeks", 12]],
+                         @reminder_interval_weeks
+                       ),
+                       id: "reminder-interval",
+                       class: "input-large" %>
       </div>
+
       <div class="form-actions">
         <%= submit_tag "Save reminder settings", class: "button-primary" %>
       </div>
     <% end %>
   </section>
-</main>
+</div>

--- a/app/views/inquiry_form/new.html.erb
+++ b/app/views/inquiry_form/new.html.erb
@@ -2,50 +2,54 @@
 <div class="volunteer-page">
   <h1 class="page-title">Inquiry</h1>
 
-  <% if @information_session_id.present? %>
-    <section class="card">
+  <section class="card">
+    <% if @information_session_id.present? %>
       <h2 class="section-heading">Walk-in: add to the system and record attendance</h2>
       <p class="help-text">
         Per session check-in: collect inquiry details. If this email already exists,
         we use the existing volunteer record and avoid duplicates.
       </p>
-
-      <%= form_with url: inquiry_form_path, method: :post, html: { class: "inquiry-form" } do %>
-        <%= hidden_field_tag :information_session_id, @information_session_id %>
-
-        <div class="inquiry-form__inline">
-          <div class="inquiry-form__row">
-            <%= label_tag :first_name, "First name" %>
-            <%= text_field_tag :first_name, params[:first_name], class: "input-large" %>
-          </div>
-
-          <div class="inquiry-form__row">
-            <%= label_tag :last_name, "Last name" %>
-            <%= text_field_tag :last_name, params[:last_name], class: "input-large" %>
-          </div>
-        </div>
-
-        <div class="inquiry-form__row">
-          <%= label_tag :email, "Email" %>
-          <%= email_field_tag :email, params[:email], class: "input-large" %>
-        </div>
-
-        <%= submit_tag "Submit and record attendance", class: "button-primary" %>
-      <% end %>
-    </section>
-  <% else %>
-    <section class="card">
+    <% else %>
       <h2 class="section-heading">Please add them to the system</h2>
-      <p class="help-text">Enter the volunteer email to continue the inquiry process.</p>
+      <p class="help-text">
+        Enter the volunteer’s information to continue the inquiry process.
+      </p>
+    <% end %>
+    <% if @form_errors.present? && @form_errors.any? %>
+      <div class="mb-4 rounded-md border border-red-300 bg-red-50 p-3 text-red-800">
+        <% @form_errors.each_value do |message| %>
+          <p><%= message %></p>
+        <% end %>
+      </div>
+    <% end %>
+    <%= form_with url: inquiry_form_path, method: :post, html: { class: "inquiry-form" } do %>
+      <% if @information_session_id.present? %>
+        <%= hidden_field_tag :information_session_id, @information_session_id %>
+      <% end %>
 
-      <%= form_with url: inquiry_form_path, method: :post, html: { class: "inquiry-form" } do %>
+      <div class="inquiry-form__inline">
         <div class="inquiry-form__row">
-          <%= label_tag :email, "Email" %>
-          <%= email_field_tag :email, nil, class: "input-large" %>
+          <%= label_tag :first_name, "First name" %>
+          <%= text_field_tag :first_name, params[:first_name], class: "input-large" %>
         </div>
 
-        <%= submit_tag "Submit", class: "button-primary" %>
-      <% end %>
-    </section>
-  <% end %>
+        <div class="inquiry-form__row">
+          <%= label_tag :last_name, "Last name" %>
+          <%= text_field_tag :last_name, params[:last_name], class: "input-large" %>
+        </div>
+      </div>
+
+      <div class="inquiry-form__row">
+        <%= label_tag :email, "Email" %>
+        <%= email_field_tag :email, params[:email], class: "input-large" %>
+      </div>
+
+      <div class="inquiry-form__row">
+        <%= label_tag :phone, "Phone" %>
+        <%= text_field_tag :phone, params[:phone], class: "input-large" %>
+      </div>
+
+      <%= submit_tag "Submit", class: "button-primary" %>
+    <% end %>
+  </section>
 </div>

--- a/app/views/inquiry_form/new.html.erb
+++ b/app/views/inquiry_form/new.html.erb
@@ -1,94 +1,51 @@
-<main class="volunteer-page">
-  <nav class="page-nav page-nav--back" aria-label="Back">
-    <% if @information_session_id.present? %>
-      <%= back_nav_link sign_in_information_session_path(@information_session_id), "Back to session check-in" %>
-    <% else %>
-      <%= back_nav_link volunteers_path, "Back to volunteers" %>
-    <% end %>
-  </nav>
-
+<!-- app/views/inquiry_form/new.html.erb -->
+<div class="volunteer-page">
   <h1 class="page-title">Inquiry</h1>
 
-  <section class="card">
-    <% if @form_errors&.dig(:base).present? %>
-      <p class="field-error"><%= @form_errors[:base] %></p>
-    <% end %>
+  <% if @information_session_id.present? %>
+    <section class="card">
+      <h2 class="section-heading">Walk-in: add to the system and record attendance</h2>
+      <p class="help-text">
+        Per session check-in: collect inquiry details. If this email already exists,
+        we use the existing volunteer record and avoid duplicates.
+      </p>
 
-    <% if @information_session_id.present? %>
-      <h2>Walk-in: add to the system and record attendance</h2>
-      <p>Per session check-in: collect inquiry details. If this email already exists, we use the existing volunteer record (no duplicate).</p>
-
-      <%= form_with url: inquiry_form_path, method: :post, local: true, html: { class: "inquiry-form" } do %>
+      <%= form_with url: inquiry_form_path, method: :post, html: { class: "inquiry-form" } do %>
         <%= hidden_field_tag :information_session_id, @information_session_id %>
-        <div class="inquiry-form__row">
-          <label for="first_name">First name</label>
-          <input type="text" id="first_name" name="first_name" value="<%= @form_values[:first_name] %>" required maxlength="100" autocomplete="given-name" class="input-large <%= 'field-invalid' if @form_errors&.dig(:first_name).present? %>">
-          <% if @form_errors&.dig(:first_name).present? %>
-            <p class="field-error"><%= @form_errors[:first_name] %></p>
-          <% end %>
-        </div>
-        <div class="inquiry-form__row">
-          <label for="last_name">Last name</label>
-          <input type="text" id="last_name" name="last_name" value="<%= @form_values[:last_name] %>" required maxlength="100" autocomplete="family-name" class="input-large <%= 'field-invalid' if @form_errors&.dig(:last_name).present? %>">
-          <% if @form_errors&.dig(:last_name).present? %>
-            <p class="field-error"><%= @form_errors[:last_name] %></p>
-          <% end %>
-        </div>
-        <div class="inquiry-form__inline">
-          <div class="inquiry-form__row">
-            <label for="email">Email</label>
-            <input type="email" id="email" name="email" value="<%= @form_values[:email] %>" required autocomplete="email" maxlength="254" class="input-large <%= 'field-invalid' if @form_errors&.dig(:email).present? %>">
-            <% if @form_errors&.dig(:email).present? %>
-              <p class="field-error"><%= @form_errors[:email] %></p>
-            <% end %>
-          </div>
-          <div class="inquiry-form__row">
-            <label for="phone">Phone</label>
-            <input type="tel" id="phone" name="phone" value="<%= @form_values[:phone] %>" required inputmode="numeric" autocomplete="tel" maxlength="20" pattern="^\D*(\d\D*){10}$" class="input-large <%= 'field-invalid' if @form_errors&.dig(:phone).present? %>">
-            <% if @form_errors&.dig(:phone).present? %>
-              <p class="field-error"><%= @form_errors[:phone] %></p>
-            <% end %>
-          </div>
-        </div>
-        <button type="submit" class="button-primary">Submit and record attendance</button>
-      <% end %>
-    <% else %>
-      <h2>Please add them to the system</h2>
-      <p>Enter volunteer contact details to continue the inquiry process.</p>
 
-      <%= form_with url: inquiry_form_path, method: :post, local: true, html: { class: "inquiry-form" } do %>
-        <div class="inquiry-form__row">
-          <label for="first_name">First name</label>
-          <input type="text" id="first_name" name="first_name" value="<%= @form_values[:first_name] %>" required maxlength="100" autocomplete="given-name" class="input-large <%= 'field-invalid' if @form_errors&.dig(:first_name).present? %>">
-          <% if @form_errors&.dig(:first_name).present? %>
-            <p class="field-error"><%= @form_errors[:first_name] %></p>
-          <% end %>
-        </div>
-        <div class="inquiry-form__row">
-          <label for="last_name">Last name</label>
-          <input type="text" id="last_name" name="last_name" value="<%= @form_values[:last_name] %>" required maxlength="100" autocomplete="family-name" class="input-large <%= 'field-invalid' if @form_errors&.dig(:last_name).present? %>">
-          <% if @form_errors&.dig(:last_name).present? %>
-            <p class="field-error"><%= @form_errors[:last_name] %></p>
-          <% end %>
-        </div>
         <div class="inquiry-form__inline">
           <div class="inquiry-form__row">
-            <label for="email">Email</label>
-            <input type="email" id="email" name="email" value="<%= @form_values[:email] %>" required autocomplete="email" maxlength="254" class="input-large <%= 'field-invalid' if @form_errors&.dig(:email).present? %>">
-            <% if @form_errors&.dig(:email).present? %>
-              <p class="field-error"><%= @form_errors[:email] %></p>
-            <% end %>
+            <%= label_tag :first_name, "First name" %>
+            <%= text_field_tag :first_name, params[:first_name], class: "input-large" %>
           </div>
+
           <div class="inquiry-form__row">
-            <label for="phone">Phone</label>
-            <input type="tel" id="phone" name="phone" value="<%= @form_values[:phone] %>" required inputmode="numeric" autocomplete="tel" maxlength="20" pattern="^\D*(\d\D*){10}$" class="input-large <%= 'field-invalid' if @form_errors&.dig(:phone).present? %>">
-            <% if @form_errors&.dig(:phone).present? %>
-              <p class="field-error"><%= @form_errors[:phone] %></p>
-            <% end %>
+            <%= label_tag :last_name, "Last name" %>
+            <%= text_field_tag :last_name, params[:last_name], class: "input-large" %>
           </div>
         </div>
-        <button type="submit" class="button-primary">Submit</button>
+
+        <div class="inquiry-form__row">
+          <%= label_tag :email, "Email" %>
+          <%= email_field_tag :email, params[:email], class: "input-large" %>
+        </div>
+
+        <%= submit_tag "Submit and record attendance", class: "button-primary" %>
       <% end %>
-    <% end %>
-  </section>
-</main>
+    </section>
+  <% else %>
+    <section class="card">
+      <h2 class="section-heading">Please add them to the system</h2>
+      <p class="help-text">Enter the volunteer email to continue the inquiry process.</p>
+
+      <%= form_with url: inquiry_form_path, method: :post, html: { class: "inquiry-form" } do %>
+        <div class="inquiry-form__row">
+          <%= label_tag :email, "Email" %>
+          <%= email_field_tag :email, nil, class: "input-large" %>
+        </div>
+
+        <%= submit_tag "Submit", class: "button-primary" %>
+      <% end %>
+    </section>
+  <% end %>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,12 @@
-<h1>Login</h1>
+<!-- app/views/sessions/new.html.erb -->
+<div class="volunteer-page">
+  <section class="card max-w-xl mx-auto">
+    <h1 class="page-title">Login</h1>
+    <p class="help-text">Sign in with your Google account to access Sprout.</p>
 
-<%= button_to "Sign in with Google", "/auth/google_oauth2", method: :post %>
-
+    <%= button_to "Sign in with Google",
+                  "/auth/google_oauth2",
+                  method: :post,
+                  class: "button-primary w-full sm:w-auto" %>
+  </section>
+</div>

--- a/app/views/shared/_main_navigation.html.erb
+++ b/app/views/shared/_main_navigation.html.erb
@@ -7,6 +7,7 @@
       <%= link_to "Inquiry", new_inquiry_form_path, class: app_nav_link_class(new_inquiry_form_path) %>
       <% if current_user.admin? %>
         <%= link_to "Dashboard", application_dashboard_path, class: app_nav_link_class(application_dashboard_path) %>
+        <%= link_to "Email Templates", admin_communication_templates_path, class: app_nav_link_class(admin_communication_templates_path) %>
         <%= link_to "Admin", admin_settings_path, class: app_nav_link_class(admin_settings_path) %>
       <% end %>
     </nav>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema[8.1].define(version: 2026_04_12_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"


### PR DESCRIPTION
This PR implements the UI for user stories 1–4.

Changes include:
- Styled inquiry form, admin settings, and login pages to match existing app design
- Implemented email template views (index, new, show, preview)
- Added email templates to main navigation
- Ensured consistent use of shared Tailwind styles across early user flows

These updates align the initial user experience with the design system used in later user stories.

<img width="1150" height="791" alt="Screenshot 2026-04-22 at 3 55 05 PM" src="https://github.com/user-attachments/assets/5d848a77-3ba1-4395-a461-d1ae982ca7fa" />


<img width="1154" height="785" alt="Screenshot 2026-04-22 at 4 03 02 PM" src="https://github.com/user-attachments/assets/37e4ac48-e7ab-482c-96f0-660e24ea4f29" />
<img width="1153" height="789" alt="Screenshot 2026-04-22 at 4 03 55 PM" src="https://github.com/user-attachments/assets/4be0a885-ed77-4d70-b9b1-09a3b145d8c5" />
