### PR TITLE
Update Email Handle from @childfocusnj.org to @passaiccountycasa.org

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
 
     email = auth.info.email
 
-    if email && (email.end_with?("@childfocusnj.org") || email.end_with?("@nyu.edu")) # added nyu for testing
+    if email && (email.end_with?("@passaiccountycasa.org") || email.end_with?("@nyu.edu")) # added nyu for testing
       name_parts = auth.info.name.to_s.split
       first_from_name = name_parts.first
       last_from_name = name_parts.length > 1 ? name_parts[1..].join(" ") : nil


### PR DESCRIPTION
@izzyyadams @wessimpson @ivlarson20 
---
## Summary of changes

Small update to change the email domain. We can send emails from @childfocusnj.org, but logging in is strictly @passaiccountycasa.org.

## Testing 

None, no testing needed here