### PR TITLE
Add RSpec tests for user stories 1-4 

### DIFF
--- a/spec/models/communication_template_spec.rb
+++ b/spec/models/communication_template_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CommunicationTemplate, type: :model do
+  describe "validations" do
+    it "is valid with all required fields" do
+      template = CommunicationTemplate.new(
+        name: "2-week follow-up",
+        body: "Hi, just checking in.",
+        funnel_stage: :inquiry,
+        trigger_type: :interval,
+        interval_weeks: 2
+      )
+      expect(template).to be_valid
+    end
+
+    it "is invalid without a name" do
+      template = CommunicationTemplate.new(body: "Hi", funnel_stage: :inquiry)
+      expect(template).not_to be_valid
+      expect(template.errors[:name]).to be_present
+    end
+
+    it "is invalid without a body" do
+      template = CommunicationTemplate.new(name: "Test", funnel_stage: :inquiry)
+      expect(template).not_to be_valid
+      expect(template.errors[:body]).to be_present
+    end
+
+    it "is invalid without a funnel_stage" do
+      template = CommunicationTemplate.new(name: "Test", body: "Hi")
+      expect(template).not_to be_valid
+      expect(template.errors[:funnel_stage]).to be_present
+    end
+  end
+
+  describe "US4: template types and trigger types" do
+    it "supports email template type" do
+      template = CommunicationTemplate.create!(name: "Email template", body: "Hi", funnel_stage: :inquiry, template_type: :email)
+      expect(template).to be_email
+    end
+
+    it "supports sms template type" do
+      template = CommunicationTemplate.create!(name: "SMS template", body: "Hi", funnel_stage: :inquiry, template_type: :sms)
+      expect(template).to be_sms
+    end
+
+    it "supports interval trigger type" do
+      template = CommunicationTemplate.create!(name: "Interval", body: "Hi", funnel_stage: :inquiry, trigger_type: :interval, interval_weeks: 2)
+      expect(template).to be_interval
+    end
+
+    it "supports event trigger type" do
+      template = CommunicationTemplate.create!(name: "Event", body: "Hi", funnel_stage: :inquiry, trigger_type: :event)
+      expect(template).to be_event
+    end
+
+    it "supports manual trigger type" do
+      template = CommunicationTemplate.create!(name: "Manual", body: "Hi", funnel_stage: :inquiry, trigger_type: :manual)
+      expect(template).to be_manual
+    end
+
+    it "supports campaign trigger type" do
+      template = CommunicationTemplate.create!(name: "Campaign", body: "Hi", funnel_stage: :inquiry, trigger_type: :campaign)
+      expect(template).to be_campaign
+    end
+  end
+
+  describe "US4: interval_weeks for configurable intervals" do
+    [ 2, 4, 8, 12 ].each do |weeks|
+      it "can be created with a #{weeks}-week interval" do
+        template = CommunicationTemplate.create!(
+          name: "#{weeks}-week follow-up",
+          body: "Following up after #{weeks} weeks.",
+          funnel_stage: :application_sent,
+          trigger_type: :interval,
+          interval_weeks: weeks
+        )
+        expect(template.interval_weeks).to eq(weeks)
+      end
+    end
+  end
+
+  describe "US4: funnel stages" do
+    it "supports inquiry stage" do
+      template = CommunicationTemplate.create!(name: "Inquiry", body: "Hi", funnel_stage: :inquiry)
+      expect(template).to be_inquiry
+    end
+
+    it "supports application_eligible stage" do
+      template = CommunicationTemplate.create!(name: "Eligible", body: "Hi", funnel_stage: :application_eligible)
+      expect(template).to be_application_eligible
+    end
+
+    it "supports application_sent stage" do
+      template = CommunicationTemplate.create!(name: "Sent", body: "Hi", funnel_stage: :application_sent)
+      expect(template).to be_application_sent
+    end
+  end
+
+  describe "US4: subject field for personalization" do
+    it "stores a subject line" do
+      template = CommunicationTemplate.create!(
+        name: "Welcome",
+        subject: "Welcome to Child Focus NJ",
+        body: "Hi, thanks for your interest.",
+        funnel_stage: :inquiry
+      )
+      expect(template.subject).to eq("Welcome to Child Focus NJ")
+    end
+
+    it "allows subject to be blank" do
+      template = CommunicationTemplate.new(name: "No subject", body: "Hi", funnel_stage: :inquiry)
+      expect(template).to be_valid
+    end
+  end
+
+  describe "US4: active/inactive templates" do
+    it "is active by default" do
+      template = CommunicationTemplate.create!(name: "Active", body: "Hi", funnel_stage: :inquiry)
+      expect(template.active).to be true
+    end
+
+    it "can be deactivated" do
+      template = CommunicationTemplate.create!(name: "Inactive", body: "Hi", funnel_stage: :inquiry, active: false)
+      expect(template.active).to be false
+    end
+  end
+
+  describe "scopes" do
+    before do
+      CommunicationTemplate.delete_all
+    end
+
+    it ".active returns only active templates" do
+      active = CommunicationTemplate.create!(name: "Active", body: "Hi", funnel_stage: :inquiry, active: true)
+      inactive = CommunicationTemplate.create!(name: "Inactive", body: "Hi", funnel_stage: :inquiry, active: false)
+
+      expect(CommunicationTemplate.active).to include(active)
+      expect(CommunicationTemplate.active).not_to include(inactive)
+    end
+
+    it ".for_stage returns templates for a given funnel stage" do
+      inquiry_template = CommunicationTemplate.create!(name: "Inquiry", body: "Hi", funnel_stage: :inquiry)
+      sent_template = CommunicationTemplate.create!(name: "Sent", body: "Hi", funnel_stage: :application_sent)
+
+      expect(CommunicationTemplate.for_stage(:inquiry)).to include(inquiry_template)
+      expect(CommunicationTemplate.for_stage(:inquiry)).not_to include(sent_template)
+    end
+
+    it ".interval_triggers returns only interval-triggered templates" do
+      interval = CommunicationTemplate.create!(name: "Interval", body: "Hi", funnel_stage: :inquiry, trigger_type: :interval)
+      manual = CommunicationTemplate.create!(name: "Manual", body: "Hi", funnel_stage: :inquiry, trigger_type: :manual)
+
+      expect(CommunicationTemplate.interval_triggers).to include(interval)
+      expect(CommunicationTemplate.interval_triggers).not_to include(manual)
+    end
+  end
+
+  describe "US3: AttendanceMailer.application_queued" do
+    it "sends an application queued email to the volunteer" do
+      mail = AttendanceMailer.application_queued("jane@childfocusnj.org")
+      expect(mail.to).to include("jane@childfocusnj.org")
+      expect(mail.subject).to eq("Application queued")
+    end
+  end
+end

--- a/spec/models/scheduled_reminder_spec.rb
+++ b/spec/models/scheduled_reminder_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScheduledReminder, type: :model do
+  let(:template) do
+    CommunicationTemplate.create!(
+      name: "2-week follow-up",
+      body: "Hi, just following up on your inquiry.",
+      funnel_stage: :inquiry,
+      trigger_type: :interval,
+      interval_weeks: 2
+    )
+  end
+  let(:volunteer) { create(:volunteer, current_funnel_stage: :inquiry) }
+
+  describe "validations" do
+    it "is invalid without a scheduled_for date" do
+      reminder = ScheduledReminder.new(volunteer: volunteer, communication_template: template, status: :pending)
+      expect(reminder).not_to be_valid
+      expect(reminder.errors[:scheduled_for]).to be_present
+    end
+
+    it "is valid with all required fields" do
+      reminder = ScheduledReminder.new(
+        volunteer: volunteer,
+        communication_template: template,
+        scheduled_for: 2.weeks.from_now,
+        status: :pending
+      )
+      expect(reminder).to be_valid
+    end
+  end
+
+  describe "statuses" do
+    it "defaults to pending" do
+      reminder = ScheduledReminder.create!(
+        volunteer: volunteer,
+        communication_template: template,
+        scheduled_for: 2.weeks.from_now
+      )
+      expect(reminder).to be_pending
+    end
+
+    it "can be marked sent" do
+      reminder = ScheduledReminder.create!(
+        volunteer: volunteer,
+        communication_template: template,
+        scheduled_for: 1.week.from_now
+      )
+      reminder.sent!
+      expect(reminder).to be_sent
+    end
+
+    it "can be cancelled" do
+      reminder = ScheduledReminder.create!(
+        volunteer: volunteer,
+        communication_template: template,
+        scheduled_for: 1.week.from_now
+      )
+      reminder.cancelled!
+      expect(reminder).to be_cancelled
+    end
+  end
+
+  describe ".due" do
+    it "returns pending reminders scheduled in the past or now" do
+      overdue = ScheduledReminder.create!(volunteer: volunteer, communication_template: template, scheduled_for: 1.day.ago, status: :pending)
+      future = ScheduledReminder.create!(volunteer: volunteer, communication_template: template, scheduled_for: 1.day.from_now, status: :pending)
+
+      expect(ScheduledReminder.due).to include(overdue)
+      expect(ScheduledReminder.due).not_to include(future)
+    end
+
+    it "does not return already sent reminders" do
+      sent = ScheduledReminder.create!(volunteer: volunteer, communication_template: template, scheduled_for: 1.day.ago, status: :sent)
+      expect(ScheduledReminder.due).not_to include(sent)
+    end
+
+    it "does not return cancelled reminders" do
+      cancelled = ScheduledReminder.create!(volunteer: volunteer, communication_template: template, scheduled_for: 1.day.ago, status: :cancelled)
+      expect(ScheduledReminder.due).not_to include(cancelled)
+    end
+  end
+
+  describe ".upcoming" do
+    it "returns pending reminders scheduled in the future, ordered by date" do
+      sooner = ScheduledReminder.create!(volunteer: volunteer, communication_template: template, scheduled_for: 1.week.from_now, status: :pending)
+      later = ScheduledReminder.create!(volunteer: volunteer, communication_template: template, scheduled_for: 4.weeks.from_now, status: :pending)
+
+      expect(ScheduledReminder.upcoming.to_a).to eq([sooner, later])
+    end
+  end
+
+  describe "US3: pending reminders cancelled when volunteer reaches applied" do
+    it "cancels all pending reminders when volunteer status becomes applied" do
+      reminder = ScheduledReminder.create!(
+        volunteer: volunteer,
+        communication_template: template,
+        scheduled_for: 2.weeks.from_now,
+        status: :pending
+      )
+
+      volunteer.update!(current_funnel_stage: :applied)
+
+      expect(reminder.reload).to be_cancelled
+    end
+
+    it "does not cancel already sent reminders when volunteer reaches applied" do
+      sent_reminder = ScheduledReminder.create!(
+        volunteer: volunteer,
+        communication_template: template,
+        scheduled_for: 1.week.ago,
+        status: :sent
+      )
+
+      volunteer.update!(current_funnel_stage: :applied)
+
+      expect(sent_reminder.reload).to be_sent
+    end
+  end
+end

--- a/spec/models/scheduled_reminder_spec.rb
+++ b/spec/models/scheduled_reminder_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ScheduledReminder, type: :model do
       sooner = ScheduledReminder.create!(volunteer: volunteer, communication_template: template, scheduled_for: 1.week.from_now, status: :pending)
       later = ScheduledReminder.create!(volunteer: volunteer, communication_template: template, scheduled_for: 4.weeks.from_now, status: :pending)
 
-      expect(ScheduledReminder.upcoming.to_a).to eq([sooner, later])
+      expect(ScheduledReminder.upcoming.to_a).to eq([ sooner, later ])
     end
   end
 

--- a/spec/requests/inquiry_form_duplicate_spec.rb
+++ b/spec/requests/inquiry_form_duplicate_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Inquiry form duplicate account prevention", type: :request do
+  let(:user) { create(:user) }
+
+  before { login_as(user, scope: :user) }
+
+  around do |example|
+    ActionMailer::Base.deliveries.clear
+    example.run
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "POST /inquiry_form duplicate email detection (no session context)" do
+    # US2: Duplicate email does not create a second volunteer
+    context "when a volunteer already exists with the submitted email" do
+      before { create(:volunteer, email: "dup@childfocusnj.org") }
+
+      it "does not create a second volunteer" do
+        expect do
+          post inquiry_form_path, params: {
+            first_name: "Jane",
+            last_name: "Doe",
+            email: "dup@childfocusnj.org",
+            phone: "5551234567"
+          }
+        end.not_to change(Volunteer, :count)
+      end
+
+      it "redirects with a duplicate email message" do
+        post inquiry_form_path, params: {
+          first_name: "Jane",
+          last_name: "Doe",
+          email: "dup@childfocusnj.org",
+          phone: "5551234567"
+        }
+        expect(response).to redirect_to(new_inquiry_form_path)
+        follow_redirect!
+        expect(response.body).to include("You&#39;ve already signed up.")
+      end
+
+      it "does not send a confirmation email" do
+        post inquiry_form_path, params: {
+          first_name: "Jane",
+          last_name: "Doe",
+          email: "dup@childfocusnj.org",
+          phone: "5551234567"
+        }
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+
+      it "does not create an InquiryFormSubmission" do
+        expect do
+          post inquiry_form_path, params: {
+            first_name: "Jane",
+            last_name: "Doe",
+            email: "dup@childfocusnj.org",
+            phone: "5551234567"
+          }
+        end.not_to change(InquiryFormSubmission, :count)
+      end
+    end
+
+    # US2: Normalized email matches an existing volunteer (trim + downcase)
+    context "when the submitted email differs only in case and whitespace" do
+      before { create(:volunteer, email: "casey@childfocusnj.org") }
+
+      it "does not create a second volunteer when email has uppercase and spaces" do
+        expect do
+          post inquiry_form_path, params: {
+            first_name: "Casey",
+            last_name: "Smith",
+            email: "  CASEY@childfocusnj.org  ",
+            phone: "5559876543"
+          }
+        end.not_to change(Volunteer, :count)
+      end
+
+      it "redirects with a duplicate email message for the normalized email" do
+        post inquiry_form_path, params: {
+          first_name: "Casey",
+          last_name: "Smith",
+          email: "  CASEY@childfocusnj.org  ",
+          phone: "5559876543"
+        }
+        expect(response).to redirect_to(new_inquiry_form_path)
+        follow_redirect!
+        expect(response.body).to include("You&#39;ve already signed up.")
+      end
+
+      it "does not create a volunteer when only casing differs" do
+        expect do
+          post inquiry_form_path, params: {
+            first_name: "Casey",
+            last_name: "Smith",
+            email: "Casey@Childfocusnj.Org",
+            phone: "5559876543"
+          }
+        end.not_to change(Volunteer, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/inquiry_form_spec.rb
+++ b/spec/requests/inquiry_form_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Inquiry form submission", type: :request do
+  let(:user) { create(:user) }
+
+  before { login_as(user, scope: :user) }
+
+  around do |example|
+    ActionMailer::Base.deliveries.clear
+    example.run
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "GET /inquiry_form/new" do
+    it "renders the inquiry form" do
+      get new_inquiry_form_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /inquiry_form (no session context)" do
+    let(:valid_params) do
+      {
+        first_name: "Jane",
+        last_name: "Doe",
+        email: "jane@childfocusnj.org",
+        phone: "5551234567"
+      }
+    end
+
+    # US1: Successful submission creates inquiry and shows confirmation
+    context "with valid params" do
+      it "creates an InquiryFormSubmission" do
+        expect do
+          post inquiry_form_path, params: valid_params
+        end.to change(InquiryFormSubmission, :count).by(1)
+      end
+
+      it "does not create a Volunteer record (public form flow)" do
+        expect do
+          post inquiry_form_path, params: valid_params
+        end.not_to change(Volunteer, :count)
+      end
+
+      it "redirects with a confirmation notice" do
+        post inquiry_form_path, params: valid_params
+        expect(response).to redirect_to(new_inquiry_form_path)
+        follow_redirect!
+        expect(response.body).to include("Thanks! Your inquiry has been submitted.")
+      end
+
+      it "stores the submission as unprocessed" do
+        post inquiry_form_path, params: valid_params
+        submission = InquiryFormSubmission.last
+        expect(submission.processed).to be false
+        expect(submission.source).to eq("public_inquiry_form")
+      end
+
+      # US3: Valid submission triggers confirmation email
+      it "sends a confirmation email to the submitted address" do
+        post inquiry_form_path, params: valid_params
+        expect(ActionMailer::Base.deliveries.size).to eq(1)
+        expect(ActionMailer::Base.deliveries.last.to).to include("jane@childfocusnj.org")
+      end
+    end
+
+    # US1: Missing required fields shows validation errors
+    context "with missing email" do
+      let(:params_missing_email) do
+        { first_name: "Jane", last_name: "Doe", email: "", phone: "5551234567" }
+      end
+
+      it "re-renders the form with 422" do
+        post inquiry_form_path, params: params_missing_email
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "does not create an InquiryFormSubmission" do
+        expect do
+          post inquiry_form_path, params: params_missing_email
+        end.not_to change(InquiryFormSubmission, :count)
+      end
+
+      # US3: Invalid submission does not send an email
+      it "does not send any email" do
+        post inquiry_form_path, params: params_missing_email
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+    end
+
+    context "with missing first name" do
+      it "re-renders the form with 422" do
+        post inquiry_form_path, params: { first_name: "", last_name: "Doe", email: "jane@childfocusnj.org", phone: "5551234567" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "with an invalid phone number" do
+      it "re-renders the form with 422" do
+        post inquiry_form_path, params: { first_name: "Jane", last_name: "Doe", email: "jane@childfocusnj.org", phone: "123" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "with an invalid email format" do
+      it "re-renders the form with 422" do
+        post inquiry_form_path, params: { first_name: "Jane", last_name: "Doe", email: "not-an-email", phone: "5551234567" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add RSpec tests for user stories 1–4
What this PR does
Adds RSpec test coverage for user stories 1–4 (form submission, account management, email automation, and email templates). Previously these user stories only had Cucumber BDD coverage. This PR adds unit and request specs that test the underlying implementation directly.
Files added

spec/requests/inquiry_form_spec.rb — US1 + US3: public form submission, validation errors, confirmation email sent/not sent
spec/requests/inquiry_form_duplicate_spec.rb — US2: duplicate email detection, email normalization (case + whitespace)
spec/models/scheduled_reminder_spec.rb — US3: reminder statuses, due/upcoming scopes, cancellation on applied
spec/models/communication_template_spec.rb — US4: template validations, types, intervals, funnel stages, scopes, AttendanceMailer

Test counts

55 new RSpec examples, 0 failures
Full suite: 177 examples, 0 failures
Cucumber: 53 passed, 4 pending (pre-existing), 0 failures

Notes

US4 Cucumber scenarios for template preview/creation are currently pending — the {{first_name}} interpolation feature is not yet implemented and will be addressed in a separate PR
Chromium was missing from the Docker image causing all Cucumber tests to fail — fixed by rebuilding the dev container